### PR TITLE
Implement site-wide grid layout for cards

### DIFF
--- a/css/home.css
+++ b/css/home.css
@@ -607,18 +607,6 @@
   padding: var(--space-4xl) var(--space-lg) var(--space-lg);
 }
 
-.card-list {
-  display: grid;
-  gap: var(--space-2xl);
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-}
-
-@media (min-width: 1024px) {
-  .card-list {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-}
-
 /* ========================================
    CONTACT SECTION
    ======================================== */

--- a/css/main.css
+++ b/css/main.css
@@ -815,6 +815,18 @@ footer {
 
 /* CARDS */
 
+.card-list {
+  display: grid;
+  gap: var(--space-2xl);
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+}
+
+@media (min-width: 1024px) {
+  .card-list {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
 .card {
   display: flex;
   flex-direction: column;
@@ -906,6 +918,11 @@ footer {
   color: var(--color-text-muted);
 }
 
+.card_dav,
+.card_tag:last-child {
+  margin-top: auto;
+}
+
 .card_detail span, .card_dav span {
   display: flex;
   align-items: center;
@@ -918,7 +935,7 @@ footer {
 }
 
 .card_tag {
-  margin-top: auto;
+  margin-top: var(--space-sm);
   font-weight: var(--fw-semibold);
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
This change organizes the post and video cards into a responsive grid layout site-wide. By moving the `.card-list` styles to `main.css`, all pages using this class (including the blog and video sections) now benefit from a consistent grid. Additionally, card footer elements were adjusted to align at the bottom, ensuring vertical symmetry regardless of content length.

---
*PR created automatically by Jules for task [1996275934752643663](https://jules.google.com/task/1996275934752643663) started by @M-DinhHoangViet*