### PR TITLE
Limit Tournament Table Height on Computer Screens & Improve search code

### DIFF
--- a/css/eventwinner.css
+++ b/css/eventwinner.css
@@ -9,7 +9,7 @@
   width: 100%;
   overflow: auto;
   max-width: inherit;
-  max-height: inherit;
+  max-height: 70vh;
   margin: var(--space-2xl) 0;
   border-radius: var(--border-radius-lg);
   background: linear-gradient(

--- a/css/eventwinner.css
+++ b/css/eventwinner.css
@@ -870,9 +870,18 @@ a
 }
 
 .score-modal-dialog {
+  display: block !important;
   max-width: 500px !important;
-  grid-template-columns: 1fr !important;
+  width: 90vw !important;
+  grid-template-columns: unset !important;
+  grid-template-rows: unset !important;
   padding: 1.5rem !important;
+}
+
+.score-modal-dialog .cc-modal-content-wrapper {
+  grid-column: unset !important;
+  grid-row: unset !important;
+  padding: 0 !important;
 }
 
 .score-detail-table {

--- a/css/eventwinner.css
+++ b/css/eventwinner.css
@@ -5,7 +5,7 @@
   width: 100%;
   overflow: auto;
   max-width: inherit;
-  max-height: 70vh;
+  max-height: 75vh;
   margin: var(--space-2xl) 0;
   border-radius: var(--border-radius-lg);
   background: linear-gradient(

--- a/css/eventwinner.css
+++ b/css/eventwinner.css
@@ -1,9 +1,5 @@
 @import url("./variables.css");
 
-/* ========================================
-   TOURNAMENT TABLE - NEW DESIGN
-   ======================================== */
-
 .table {
   position: relative;
   width: 100%;

--- a/css/eventwinner.css
+++ b/css/eventwinner.css
@@ -17,7 +17,7 @@
     rgba(10, 15, 26, 0.9) 0%,
     rgba(15, 25, 45, 0.8) 100%
   );
-  padding: 4px;
+  padding: 0;
   box-shadow: var(--shadow-xl);
   transition: all var(--transition-base);
 }
@@ -664,7 +664,6 @@ a
   display: flex;
   gap: 1rem;
   align-items: flex-start;
-  margin-bottom: 1.2rem;
 }
 
 .cc-modal-logo-box {
@@ -871,11 +870,12 @@ a
 
 .score-modal-dialog {
   display: block !important;
-  max-width: 500px !important;
+  max-width: 90vw !important;
   width: 90vw !important;
   grid-template-columns: unset !important;
   grid-template-rows: unset !important;
   padding: 1.5rem !important;
+  overflow: scroll;
 }
 
 .score-modal-dialog .cc-modal-content-wrapper {

--- a/events/tournaments/cttq.md
+++ b/events/tournaments/cttq.md
@@ -16,4 +16,4 @@ title: Bảng tổng giải Chiến Trường Thí Quân
 
 <script src="/js/aggregated-fetcher.js"></script>
 
-<a href="/events/cttq-chien-truong-thi-quan"><img alt="Chiến Trường Thí Quân logo" src="/images/events/logo/cttq.png"></a>
+<a href="/events/cttq-chien-truong-thi-quan"><img alt="Chiến Trường Thí Quân logo" src="/images/events/logo/cttq.png" width="250"></a>

--- a/events/tournaments/cttq.md
+++ b/events/tournaments/cttq.md
@@ -14,19 +14,6 @@ title: Bảng tổng giải Chiến Trường Thí Quân
 <p><i>Nếu có đề xuất hoặc vấn đề gì thì hãy bình luận <a href="https://chess.com/clubs/forum/view/danh-sach-cac-giai-da-to-chuc-clb-tvlt?clubId=325849&quote_id=131524731&page=1#comment_box" target="_blank">forum này</a> hoặc liên hệ <a href="/leaders#admin3" target="_top">Admin M-DinhHoangViet</a>.</i></p>
 <div id="cttq-months-container" data-fetch-aggregated="cttq"></div>
 
-<div id="scoreModal" class="cc-modal-overlay">
-    <div class="cc-modal-dialog score-modal-dialog">
-        <button class="cc-modal-close" onclick="ModalManager.close()">×</button>
-        <div class="cc-modal-content-wrapper">
-            <div class="cc-modal-header-row">
-                <div class="cc-modal-title-section">
-                    <h2 id="modal-player-name">Chi tiết điểm</h2>
-                </div>
-            </div>
-            <div id="modal-score-breakdown"></div>
-        </div>
-    </div>
-</div>
 <script src="/js/aggregated-fetcher.js"></script>
 
 <a href="/events/cttq-chien-truong-thi-quan"><img alt="Chiến Trường Thí Quân logo" src="/images/events/logo/cttq.png"></a>

--- a/events/tournaments/tvlt.md
+++ b/events/tournaments/tvlt.md
@@ -14,4 +14,4 @@ title: Bảng tổng giải Thí Vua Lấy Tốt
 <p><i>Nếu có đề xuất hoặc vấn đề gì thì hãy bình luận <a href="https://chess.com/clubs/forum/view/danh-sach-cac-giai-da-to-chuc-clb-tvlt?clubId=325849&quote_id=131524731&page=1#comment_box" target="_blank">forum này</a> hoặc liên hệ <a href="/leaders#admin3" target="_top">Admin M-DinhHoangViet</a>.</i></p>
 <div id="tournament-table" data-fetch-tournament="tvlt"></div>
 
-<a href="/events/tvlt-thi-vua-lay-tot"><img src="/images/tvltlogo.png" alt="TungJohn Playing Chess"></a>
+<a href="/events/tvlt-thi-vua-lay-tot"><img src="/images/tvltlogo.png" alt="TungJohn Playing Chess" width="250"></a>

--- a/js/aggregated-fetcher.js
+++ b/js/aggregated-fetcher.js
@@ -305,7 +305,7 @@
             container.innerHTML = `<input type="text" id="searchInput" class="search-bar" onkeyup="searchTable()" placeholder="Tìm kiếm...">
                 <div id="loading-status" style="text-align: center; padding: 20px; font-size: 14px;">Đang xử lý: <span id="statusIcon" class="bx bx-dots-horizontal-rounded" style="color: var(--primary-warning)"></span> <span id="current-tournament">0</span>/${months.length} tháng</div>
                 <div class="table"><table class="styled-table" id="tournament-results-table"><thead><tr><th class="name-tour">Tháng</th><th class="organization-day">Thống kê</th><th class="players">Kỳ thủ</th>
-                <th class="winner">🥇 Top 1</th><th class="winner">🥈 Top 2</th><th class="winner">🥉 Top 3</th><th class="winner">🎖️ Top 4</th><th class="winner">🏅 Top 5</th><th class="winner">⭐ Top 6</th></tr></thead><tbody id="tournament-tbody"></tbody></table></div>`;
+                <th class="winner">🥇 Top 1</th><th class="winner">🥈 Top 2</th><th class="winner">🥉 Top 3</th><th class="winner">🎖️ Top 4</th><th class="winner">🏅 Top 5</th><th class="winner">⭐ Top 6</th></tr></thead><tbody id="tournament-tbody"><tr class="not-match"><td style="color: var(--color-warning)">Không tìm thấy kết quả nào!</td></tr></tbody></table></div>`;
 
             const tbody = document.getElementById('tournament-tbody');
             const skeletons = months.map(() => {

--- a/js/aggregated-fetcher.js
+++ b/js/aggregated-fetcher.js
@@ -323,19 +323,7 @@
                 tbody.appendChild(tr); return tr;
             });
 
-            let count = 0;
-            await Promise.allSettled(months.map(async (m, i) => {
-                try {
-                    const html = await Renderer.monthRow(m, eventType);
-                    const temp = document.createElement('tbody'); temp.innerHTML = html;
-                    skeletons[i].replaceWith(temp.firstElementChild);
-                    document.getElementById('current-tournament').textContent = ++count;
-                } catch (e) {}
-            }));
-
-            const icon = document.getElementById('statusIcon');
-            if (icon) { icon.style.color = count === months.length ? 'var(--primary-success)' : 'var(--color-danger)'; icon.className = count === months.length ? 'bx bx-check' : 'bx bx-x'; }
-
+            // Set up event listeners early so users can click loaded months while remaining months load
             document.getElementById('scoreModal')?.addEventListener('click', e => {
                 if (e.target.id === 'scoreModal') ModalManager.close();
                 const customLink = e.target.closest('.custom-variant-link');
@@ -367,6 +355,19 @@
                     ModalManager.show(`Chi tiết tháng ${month.dataset.month}`, h + '</tbody></table></div>');
                 }
             });
+
+            let count = 0;
+            await Promise.allSettled(months.map(async (m, i) => {
+                try {
+                    const html = await Renderer.monthRow(m, eventType);
+                    const temp = document.createElement('tbody'); temp.innerHTML = html;
+                    skeletons[i].replaceWith(temp.firstElementChild);
+                    document.getElementById('current-tournament').textContent = ++count;
+                } catch (e) {}
+            }));
+
+            const icon = document.getElementById('statusIcon');
+            if (icon) { icon.style.color = count === months.length ? 'var(--primary-success)' : 'var(--color-danger)'; icon.className = count === months.length ? 'bx bx-check' : 'bx bx-x'; }
         }
     };
 

--- a/js/aggregated-fetcher.js
+++ b/js/aggregated-fetcher.js
@@ -305,7 +305,7 @@
             container.innerHTML = `<input type="text" id="searchInput" class="search-bar" onkeyup="searchTable()" placeholder="Tìm kiếm...">
                 <div id="loading-status" style="text-align: center; padding: 20px; font-size: 14px;">Đang xử lý: <span id="statusIcon" class="bx bx-dots-horizontal-rounded" style="color: var(--primary-warning)"></span> <span id="current-tournament">0</span>/${months.length} tháng</div>
                 <div class="table"><table class="styled-table" id="tournament-results-table"><thead><tr><th class="name-tour">Tháng</th><th class="organization-day">Thống kê</th><th class="players">Kỳ thủ</th>
-                <th class="winner">🥇 Top 1</th><th class="winner">🥈 Top 2</th><th class="winner">🥉 Top 3</th><th class="winner">🎖️ Top 4</th><th class="winner">🏅 Top 5</th><th class="winner">⭐ Top 6</th></tr></thead><tbody id="tournament-tbody"><tr class="not-match"><td style="color: var(--color-warning)">Không tìm thấy kết quả nào!</td></tr></tbody></table></div>`;
+                <th class="winner">🥇 Top 1</th><th class="winner">🥈 Top 2</th><th class="winner">🥉 Top 3</th><th class="winner">🎖️ Top 4</th><th class="winner">🏅 Top 5</th><th class="winner">⭐ Top 6</th></tr></thead><tbody id="tournament-tbody"><tr class="not-match" style="display: none"><td style="color: var(--color-warning)">Không tìm thấy kết quả nào!</td></tr></tbody></table></div>`;
 
             const tbody = document.getElementById('tournament-tbody');
             const skeletons = months.map(() => {

--- a/js/search-events.js
+++ b/js/search-events.js
@@ -32,8 +32,8 @@ window.searchTable = debounce(function() {
     const rows = table.getElementsByTagName('tr');
     let matched = false;
 
-    // Iterate through all table rows, skipping the header (i=1)
-    for (let i = 1; i < rows.length; i++) {
+    // Iterate through all table rows, skipping the header & alert
+    for (let i = 2; i < rows.length; i++) {
         const cells = rows[i].getElementsByTagName('td');
         let match = false;
 

--- a/js/search-events.js
+++ b/js/search-events.js
@@ -31,6 +31,14 @@ window.searchTable = debounce(function() {
 
     const rows = table.getElementsByTagName('tr');
 
+    if (!rows.length) {
+        table.querySelector('.not-match').style.display = '';
+        return;
+    }
+    else {
+        table.querySelector('.not-match').style.display = 'none';
+    }
+
     // Iterate through all table rows, skipping the header (i=1)
     for (let i = 1; i < rows.length; i++) {
         const cells = rows[i].getElementsByTagName('td');

--- a/js/search-events.js
+++ b/js/search-events.js
@@ -31,9 +31,8 @@ window.searchTable = debounce(function() {
 
     const rows = table.getElementsByTagName('tr');
 
-    if (rows.length > 1) {
+    if (rows.length < 2) {
         table.querySelector('.not-match').style.display = '';
-        return;
     }
     else {
         table.querySelector('.not-match').style.display = 'none';

--- a/js/search-events.js
+++ b/js/search-events.js
@@ -30,13 +30,7 @@ window.searchTable = debounce(function() {
     if (!table) return;
 
     const rows = table.getElementsByTagName('tr');
-
-    if (rows.length < 2) {
-        table.querySelector('.not-match').style.display = '';
-    }
-    else {
-        table.querySelector('.not-match').style.display = 'none';
-    }
+    let matched = false;
 
     // Iterate through all table rows, skipping the header (i=1)
     for (let i = 1; i < rows.length; i++) {
@@ -48,6 +42,7 @@ window.searchTable = debounce(function() {
             const cell = cells[j];
             if (cell && cell.textContent.toUpperCase().indexOf(filter) > -1) {
                 match = true;
+                matched = true;
                 break;
             }
         }
@@ -55,4 +50,5 @@ window.searchTable = debounce(function() {
         // Toggle row visibility based on match result
         rows[i].style.display = match ? '' : 'none';
     }
+    table.querySelector('.not-match').style.display = matched ? 'none' : '';
 }, 100);

--- a/js/search-events.js
+++ b/js/search-events.js
@@ -31,7 +31,7 @@ window.searchTable = debounce(function() {
 
     const rows = table.getElementsByTagName('tr');
 
-    if (!rows.length) {
+    if (rows.length > 1) {
         table.querySelector('.not-match').style.display = '';
         return;
     }

--- a/js/tournament-fetcher.js
+++ b/js/tournament-fetcher.js
@@ -179,7 +179,7 @@
         el.innerHTML = `<input type="text" id="searchInput" class="search-bar" onkeyup="searchTable()" placeholder="Tìm kiếm...">
             <div id="loading-status" style="text-align:center;padding:20px;font-size:14px">Đang hiển thị: <span id="statusIcon" class="bx bx-dots-horizontal-rounded" style="color:var(--primary-warning)"></span> <span id="current-tournament">0</span>/${ids.length} giải đấu</div>
             <div class="table"><table class="styled-table" id="tournament-results-table"><thead><tr><th class="name-tour">Giải đấu</th><th class="organization-day">Thời gian bắt đầu</th><th class="rules">Thể lệ</th><th class="players">Kỳ thủ</th>
-            <th class="winner">🥇 Top 1</th><th class="winner">🥈 Top 2</th><th class="winner">🥉 Top 3</th><th class="winner">🎖️ Top 4</th><th class="winner">🏅 Top 5</th><th class="winner">⭐ Top 6</th></tr></thead><tbody id="tournament-tbody"></tbody></table></div><br><br><hr>`;
+            <th class="winner">🥇 Top 1</th><th class="winner">🥈 Top 2</th><th class="winner">🥉 Top 3</th><th class="winner">🎖️ Top 4</th><th class="winner">🏅 Top 5</th><th class="winner">⭐ Top 6</th></tr></thead><tbody id="tournament-tbody"><tr class="not-match" style="display:none"><td style="color:var(--color-warning)">Không tìm thấy kết quả nào!</td></tr></tbody></table></div><br><br><hr>`;
 
         const tbody = document.getElementById('tournament-tbody');
         const skeletons = ids.map(() => {

--- a/js/tournament-fetcher.js
+++ b/js/tournament-fetcher.js
@@ -82,7 +82,7 @@
         vLink(v, setup = null) {
             const d = VARIANTS[v.toLowerCase()] || { name: v, url: '/terms', icon: '/bundles/web/images/icons/smileys/2x/board.png' };
             if (setup) {
-                return ` <a href="javascript:void(0)" class="custom-variant-link" data-setup="${setup}">${d.name}${this.img(CONFIG.CHESS_COM_URL + d.icon)}</a><br>`;
+                return `<br><a href="javascript:void(0)" class="custom-variant-link" data-setup="${setup}">${d.name}${this.img(CONFIG.CHESS_COM_URL + d.icon)}</a><br>`;
             }
             return ` <a href="${CONFIG.CHESS_COM_URL}${d.url}" target="_blank">${d.name} ${this.img(CONFIG.CHESS_COM_URL + d.icon)}</a><br>`;
         },


### PR DESCRIPTION
This change resolves a desktop UX issue where long tournament tables (like TVLT and CTTQ) forced users to scroll all the way to the bottom of the page to access the horizontal scrollbar. By applying a `max-height: 70vh;` and maintaining the sticky table header (`thead { position: sticky; top: 0; }`), tables are now neatly constrained vertically with a scrollbar inside the viewport.

---
*PR created automatically by Jules for task [12226039121499643113](https://jules.google.com/task/12226039121499643113) started by @M-DinhHoangViet*