### PR TITLE
Feature: Add advanced sorting and filtering for Schedule and Tournaments

### DIFF
--- a/css/eventwinner.css
+++ b/css/eventwinner.css
@@ -274,35 +274,95 @@ a
 }
 
 /* ========================================
-   SEARCH BAR
+   SEARCH BAR & FILTERS
    ======================================== */
 
-.search-bar {
-  padding: var(--space-md);
+.filter-group-container {
+  display: flex;
+  gap: var(--space-md);
   margin: var(--space-lg) 0;
+  flex-wrap: wrap;
+  align-items: center;
+  width: 100%;
+}
+
+.filter-group-container .search-bar {
+  margin: 0;
+  flex: 1;
+  min-width: 250px;
+  padding: var(--space-md);
   border: var(--border-width-base) solid rgba(56, 189, 248, 0.3);
   background: rgba(25, 40, 75, 0.6);
   color: var(--neutral-100);
   border-radius: var(--border-radius-lg);
   font-size: var(--fs-sm);
   transition: all var(--transition-base);
-  width: 350px;
-  max-width: 100%;
   font-family: var(--primary-font);
   font-weight: var(--fw-medium);
 }
 
-.search-bar::placeholder {
+.filter-group-container .search-bar::placeholder {
   color: var(--neutral-600);
 }
 
-.search-bar:focus {
+.filter-group-container .search-bar:focus {
   outline: none;
   border-color: var(--color-primary-light);
   background: rgba(25, 40, 75, 0.95);
   box-shadow: 0 0 20px rgba(56, 189, 248, 0.3),
     inset 0 1px 3px rgba(56, 189, 248, 0.1);
   transform: translateY(-2px);
+}
+
+.select-filters {
+  display: flex;
+  gap: var(--space-md);
+  flex-wrap: wrap;
+}
+
+.select-filters select {
+  padding: var(--space-md);
+  border: var(--border-width-base) solid rgba(56, 189, 248, 0.3);
+  background: rgba(25, 40, 75, 0.6);
+  color: var(--neutral-100);
+  border-radius: var(--border-radius-lg);
+  font-size: var(--fs-sm);
+  transition: all var(--transition-base);
+  font-family: var(--primary-font);
+  font-weight: var(--fw-medium);
+  cursor: pointer;
+  outline: none;
+  min-width: 150px;
+}
+
+.select-filters select:focus {
+  border-color: var(--color-primary-light);
+  background: rgba(25, 40, 75, 0.95);
+  box-shadow: 0 0 20px rgba(56, 189, 248, 0.3);
+  transform: translateY(-2px);
+}
+
+@media (max-width: 768px) {
+  .filter-group-container {
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--space-sm);
+  }
+
+  .filter-group-container .search-bar {
+    width: 100%;
+    min-width: unset;
+  }
+
+  .select-filters {
+    flex-direction: column;
+    gap: var(--space-sm);
+  }
+
+  .select-filters select {
+    width: 100%;
+    min-width: unset;
+  }
 }
 
 /* ========================================

--- a/css/eventwinner.css
+++ b/css/eventwinner.css
@@ -503,8 +503,8 @@ a
   border: var(--border-width-thin) solid rgba(56, 189, 248, 0.2);
 }
 
-/* FIDE Style Filter System */
-.fide-top-grid {
+/* Tour Filter System */
+.tour-top-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: var(--space-md);
@@ -512,12 +512,12 @@ a
   width: 100%;
 }
 
-.fide-dropdown {
+.tour-dropdown {
   position: relative;
   width: 100%;
 }
 
-.fide-dropdown-btn {
+.tour-dropdown-btn {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -534,35 +534,35 @@ a
   box-shadow: var(--shadow-sm);
 }
 
-.fide-dropdown-btn:hover {
+.tour-dropdown-btn:hover {
   background: rgba(25, 40, 75, 0.8);
   border-color: var(--color-primary-light);
   box-shadow: 0 0 15px rgba(56, 189, 248, 0.2);
 }
 
-.fide-dropdown-btn-content {
+.tour-dropdown-btn-content {
   display: flex;
   align-items: center;
   gap: var(--space-md);
 }
 
-.fide-dropdown-btn-content i {
+.tour-dropdown-btn-content i {
   font-size: var(--fs-xl);
   color: var(--color-primary-light);
 }
 
-.fide-dropdown-arrow {
+.tour-dropdown-arrow {
   transition: transform var(--transition-base);
   font-size: var(--fs-base);
   color: var(--neutral-400);
 }
 
-.fide-dropdown.open .fide-dropdown-arrow {
+.tour-dropdown.open .tour-dropdown-arrow {
   transform: rotate(180deg);
   color: var(--color-primary-light);
 }
 
-.fide-dropdown-menu {
+.tour-dropdown-menu {
   position: absolute;
   top: calc(100% + 8px);
   left: 0;
@@ -580,11 +580,11 @@ a
   overflow-y: auto;
 }
 
-.fide-dropdown.open .fide-dropdown-menu {
+.tour-dropdown.open .tour-dropdown-menu {
   display: flex;
 }
 
-.fide-dropdown-menu .custom-checkbox-container {
+.tour-dropdown-menu .custom-checkbox-container {
   width: 100%;
   padding: var(--space-sm) var(--space-sm) var(--space-sm) 34px;
   margin: 0;
@@ -592,16 +592,16 @@ a
   transition: all var(--transition-fast);
 }
 
-.fide-dropdown-menu .custom-checkbox-container:hover {
+.tour-dropdown-menu .custom-checkbox-container:hover {
   background: rgba(56, 189, 248, 0.1);
   color: var(--neutral-100);
 }
 
-.fide-dropdown-menu .checkmark {
+.tour-dropdown-menu .checkmark {
   left: var(--space-sm);
 }
 
-.fide-select-btn {
+.tour-select-btn {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -626,18 +626,18 @@ a
   outline: none;
 }
 
-.fide-select-btn:hover {
+.tour-select-btn:hover {
   background: rgba(25, 40, 75, 0.8);
   border-color: var(--color-primary-light);
   box-shadow: 0 0 15px rgba(56, 189, 248, 0.2);
 }
 
-.fide-select-btn option {
+.tour-select-btn option {
   background-color: rgba(12, 20, 38, 0.98);
   color: var(--neutral-100);
 }
 
-.fide-search-row {
+.tour-search-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -647,13 +647,13 @@ a
   flex-wrap: wrap;
 }
 
-.fide-search-wrapper {
+.tour-search-wrapper {
   position: relative;
   flex: 1;
   min-width: 250px;
 }
 
-.fide-search-input {
+.tour-search-input {
   width: 100%;
   padding: 12px 16px 12px 42px;
   background: rgba(15, 23, 42, 0.6);
@@ -665,13 +665,13 @@ a
   outline: none;
 }
 
-.fide-search-input:focus {
+.tour-search-input:focus {
   border-color: var(--color-primary-light);
   background: rgba(25, 40, 75, 0.95);
   box-shadow: 0 0 20px rgba(56, 189, 248, 0.3);
 }
 
-.fide-search-icon {
+.tour-search-icon {
   position: absolute;
   left: 16px;
   top: 50%;
@@ -681,7 +681,7 @@ a
   pointer-events: none;
 }
 
-.fide-switch-container {
+.tour-switch-container {
   display: inline-flex;
   align-items: center;
   gap: var(--space-md);
@@ -692,20 +692,20 @@ a
   font-weight: var(--fw-medium);
 }
 
-.fide-switch {
+.tour-switch {
   position: relative;
   display: inline-block;
   width: 44px;
   height: 22px;
 }
 
-.fide-switch input {
+.tour-switch input {
   opacity: 0;
   width: 0;
   height: 0;
 }
 
-.fide-slider {
+.tour-slider {
   position: absolute;
   cursor: pointer;
   top: 0;
@@ -718,7 +718,7 @@ a
   border-radius: 34px;
 }
 
-.fide-slider:before {
+.tour-slider:before {
   position: absolute;
   content: "";
   height: 14px;
@@ -730,21 +730,37 @@ a
   border-radius: 50%;
 }
 
-.fide-switch input:checked + .fide-slider {
+.tour-switch input:checked + .tour-slider {
   background-color: rgba(56, 189, 248, 0.2);
   border-color: var(--color-primary-light);
 }
 
-.fide-switch input:checked + .fide-slider:before {
+.tour-switch input:checked + .tour-slider:before {
   transform: translateX(20px);
   background-color: var(--color-primary-light);
   box-shadow: 0 0 8px var(--color-primary-light);
 }
 
 @media (max-width: 768px) {
-  .fide-top-grid {
-    grid-template-columns: 1fr;
-    gap: var(--space-sm);
+  .tour-top-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+    margin-bottom: 12px;
+  }
+  .tour-dropdown-btn,
+  .tour-select-btn {
+    padding: 10px 14px;
+    font-size: 13px;
+    border-radius: var(--border-radius-md);
+  }
+  .tour-dropdown-btn-content {
+    gap: var(--space-xs);
+  }
+  .tour-dropdown-btn-content i {
+    font-size: var(--fs-lg);
+  }
+  .tour-dropdown-arrow {
+    font-size: var(--fs-xs);
   }
 }
 

--- a/css/eventwinner.css
+++ b/css/eventwinner.css
@@ -502,7 +502,7 @@ a
 /* FIDE Style Filter System */
 .fide-top-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: var(--space-md);
   margin-bottom: var(--space-md);
   width: 100%;

--- a/css/eventwinner.css
+++ b/css/eventwinner.css
@@ -268,6 +268,10 @@ a
   border: var(--border-width-thin) solid rgba(251, 191, 36, 0.4);
 }
 
+.hide-premium .user-badges-premium {
+  display: none !important;
+}
+
 .post-view-meta-separator {
   color: var(--neutral-600);
   margin: 0 var(--space-xs);

--- a/css/eventwinner.css
+++ b/css/eventwinner.css
@@ -279,10 +279,9 @@ a
 
 .filter-group-container {
   display: flex;
+  flex-direction: column;
   gap: var(--space-md);
   margin: var(--space-lg) 0;
-  flex-wrap: wrap;
-  align-items: center;
   width: 100%;
 }
 
@@ -314,13 +313,95 @@ a
   transform: translateY(-2px);
 }
 
-.select-filters {
-  display: flex;
-  gap: var(--space-md);
-  flex-wrap: wrap;
+/* Custom Checkbox Container */
+.custom-checkbox-container {
+  display: inline-flex;
+  align-items: center;
+  position: relative;
+  padding-left: 28px;
+  margin-right: 15px;
+  margin-bottom: 8px;
+  cursor: pointer;
+  font-size: var(--fs-sm);
+  color: var(--neutral-200);
+  user-select: none;
+  transition: all var(--transition-base);
 }
 
-.select-filters select {
+.custom-checkbox-container input {
+  position: absolute;
+  opacity: 0;
+  cursor: pointer;
+  height: 0;
+  width: 0;
+}
+
+/* Checkmark box */
+.checkmark {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  transform: translateY(-50%);
+  height: 18px;
+  width: 18px;
+  background-color: rgba(10, 25, 47, 0.7);
+  border: 1.5px solid rgba(56, 189, 248, 0.4);
+  border-radius: var(--border-radius-sm);
+  box-shadow: 0 0 5px rgba(56, 189, 248, 0.1);
+  transition: all var(--transition-base);
+}
+
+/* Hover effect */
+.custom-checkbox-container:hover .checkmark {
+  border-color: rgba(56, 189, 248, 0.8);
+  box-shadow: 0 0 8px rgba(56, 189, 248, 0.3);
+}
+
+/* Checked state */
+.custom-checkbox-container input:checked ~ .checkmark {
+  background-color: rgba(56, 189, 248, 0.2);
+  border-color: var(--color-primary-light);
+  box-shadow: 0 0 10px rgba(56, 189, 248, 0.5);
+}
+
+/* Checked checkmark shape */
+.checkmark:after {
+  content: "";
+  position: absolute;
+  display: none;
+}
+
+.custom-checkbox-container input:checked ~ .checkmark:after {
+  display: block;
+}
+
+.custom-checkbox-container .checkmark:after {
+  left: 5px;
+  top: 2px;
+  width: 5px;
+  height: 9px;
+  border: solid rgba(56, 189, 248, 0.9);
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+
+/* Filter checkboxes layout */
+.filter-row-top {
+  display: flex;
+  gap: var(--space-lg);
+  align-items: center;
+  width: 100%;
+  flex-wrap: wrap;
+  margin-bottom: var(--space-md);
+}
+
+.sort-select-wrapper {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+}
+
+.sort-select-wrapper select {
   padding: var(--space-md);
   border: var(--border-width-base) solid rgba(56, 189, 248, 0.3);
   background: rgba(25, 40, 75, 0.6);
@@ -332,36 +413,72 @@ a
   font-weight: var(--fw-medium);
   cursor: pointer;
   outline: none;
-  min-width: 150px;
 }
 
-.select-filters select:focus {
+.sort-select-wrapper select:focus {
   border-color: var(--color-primary-light);
   background: rgba(25, 40, 75, 0.95);
   box-shadow: 0 0 20px rgba(56, 189, 248, 0.3);
   transform: translateY(-2px);
 }
 
+.filter-checkboxes-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  width: 100%;
+}
+
+.filter-checkbox-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  width: 100%;
+}
+
+.filter-label {
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-bold);
+  color: rgba(56, 189, 248, 0.8);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.checkbox-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px 12px;
+  width: 100%;
+  background: rgba(10, 25, 47, 0.3);
+  padding: 10px 15px;
+  border-radius: var(--border-radius-lg);
+  border: var(--border-width-thin) solid rgba(56, 189, 248, 0.2);
+}
+
 @media (max-width: 768px) {
-  .filter-group-container {
+  .filter-row-top {
     flex-direction: column;
     align-items: stretch;
     gap: var(--space-sm);
   }
 
-  .filter-group-container .search-bar {
+  .filter-row-top .search-bar {
     width: 100%;
     min-width: unset;
   }
 
-  .select-filters {
+  .sort-select-wrapper {
     flex-direction: column;
-    gap: var(--space-sm);
+    align-items: stretch;
+    gap: var(--space-xs);
   }
 
-  .select-filters select {
+  .sort-select-wrapper select {
     width: 100%;
-    min-width: unset;
+  }
+
+  .checkbox-group {
+    padding: 8px 12px;
   }
 }
 

--- a/css/eventwinner.css
+++ b/css/eventwinner.css
@@ -401,6 +401,50 @@ a
   gap: var(--space-md);
 }
 
+/* Filter toggle button styling */
+.btn-toggle-filters {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  background: rgba(25, 40, 75, 0.6);
+  border: var(--border-width-base) solid rgba(56, 189, 248, 0.3);
+  border-radius: var(--border-radius-lg);
+  color: var(--neutral-100);
+  padding: var(--space-md);
+  font-size: var(--fs-sm);
+  font-family: var(--primary-font);
+  font-weight: var(--fw-medium);
+  cursor: pointer;
+  transition: all var(--transition-base);
+  outline: none;
+  height: max-content;
+}
+
+.btn-toggle-filters:hover,
+.btn-toggle-filters.active {
+  background: rgba(25, 40, 75, 0.95);
+  border-color: var(--color-primary-light);
+  color: var(--neutral-100);
+  box-shadow: 0 0 20px rgba(56, 189, 248, 0.3);
+  transform: translateY(-2px);
+}
+
+/* Collapsible Panel styling */
+.collapsible-panel {
+  animation: slideDown 0.3s ease-out;
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 .sort-select-wrapper select {
   padding: var(--space-md);
   border: var(--border-width-base) solid rgba(56, 189, 248, 0.3);

--- a/css/eventwinner.css
+++ b/css/eventwinner.css
@@ -535,6 +535,25 @@ a
   font-weight: var(--fw-medium);
 }
 
+#loading-status.loading-status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-xs);
+  padding: 6px 12px;
+  margin: 0;
+  background: rgba(30, 41, 59, 0.6);
+  border: var(--border-width-thin) solid rgba(56, 189, 248, 0.2);
+  border-radius: var(--border-radius-lg);
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-medium);
+  color: var(--neutral-200);
+  white-space: nowrap;
+  flex-shrink: 0;
+  height: max-content;
+  width: max-content;
+}
+
 #pause-status {
   color: var(--red-300);
   font-weight: var(--fw-bold);

--- a/css/eventwinner.css
+++ b/css/eventwinner.css
@@ -499,6 +499,251 @@ a
   border: var(--border-width-thin) solid rgba(56, 189, 248, 0.2);
 }
 
+/* FIDE Style Filter System */
+.fide-top-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-md);
+  margin-bottom: var(--space-md);
+  width: 100%;
+}
+
+.fide-dropdown {
+  position: relative;
+  width: 100%;
+}
+
+.fide-dropdown-btn {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 14px 20px;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1.5px solid rgba(56, 189, 248, 0.15);
+  border-radius: var(--border-radius-lg);
+  color: var(--neutral-100);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-semibold);
+  cursor: pointer;
+  transition: all var(--transition-base);
+  box-shadow: var(--shadow-sm);
+}
+
+.fide-dropdown-btn:hover {
+  background: rgba(25, 40, 75, 0.8);
+  border-color: var(--color-primary-light);
+  box-shadow: 0 0 15px rgba(56, 189, 248, 0.2);
+}
+
+.fide-dropdown-btn-content {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+}
+
+.fide-dropdown-btn-content i {
+  font-size: var(--fs-xl);
+  color: var(--color-primary-light);
+}
+
+.fide-dropdown-arrow {
+  transition: transform var(--transition-base);
+  font-size: var(--fs-base);
+  color: var(--neutral-400);
+}
+
+.fide-dropdown.open .fide-dropdown-arrow {
+  transform: rotate(180deg);
+  color: var(--color-primary-light);
+}
+
+.fide-dropdown-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  width: 100%;
+  background: rgba(12, 20, 38, 0.98);
+  border: var(--border-width-base) solid var(--color-primary-light);
+  border-radius: var(--border-radius-lg);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5), 0 0 15px rgba(56, 189, 248, 0.2);
+  padding: var(--space-sm);
+  z-index: 150;
+  display: none;
+  flex-direction: column;
+  gap: var(--space-xs);
+  max-height: 250px;
+  overflow-y: auto;
+}
+
+.fide-dropdown.open .fide-dropdown-menu {
+  display: flex;
+}
+
+.fide-dropdown-menu .custom-checkbox-container {
+  width: 100%;
+  padding: var(--space-sm) var(--space-sm) var(--space-sm) 34px;
+  margin: 0;
+  border-radius: var(--border-radius-md);
+  transition: all var(--transition-fast);
+}
+
+.fide-dropdown-menu .custom-checkbox-container:hover {
+  background: rgba(56, 189, 248, 0.1);
+  color: var(--neutral-100);
+}
+
+.fide-dropdown-menu .checkmark {
+  left: var(--space-sm);
+}
+
+.fide-select-btn {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 14px 20px;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1.5px solid rgba(56, 189, 248, 0.15);
+  border-radius: var(--border-radius-lg);
+  color: var(--neutral-100);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-semibold);
+  cursor: pointer;
+  transition: all var(--transition-base);
+  box-shadow: var(--shadow-sm);
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2338bdf8' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 20px center;
+  background-size: 16px;
+  padding-right: 44px;
+  outline: none;
+}
+
+.fide-select-btn:hover {
+  background: rgba(25, 40, 75, 0.8);
+  border-color: var(--color-primary-light);
+  box-shadow: 0 0 15px rgba(56, 189, 248, 0.2);
+}
+
+.fide-select-btn option {
+  background-color: rgba(12, 20, 38, 0.98);
+  color: var(--neutral-100);
+}
+
+.fide-search-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  gap: var(--space-md);
+  margin-bottom: var(--space-md);
+  flex-wrap: wrap;
+}
+
+.fide-search-wrapper {
+  position: relative;
+  flex: 1;
+  min-width: 250px;
+}
+
+.fide-search-input {
+  width: 100%;
+  padding: 12px 16px 12px 42px;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1.5px solid rgba(56, 189, 248, 0.15);
+  border-radius: var(--border-radius-lg);
+  color: var(--neutral-100);
+  font-size: var(--fs-sm);
+  transition: all var(--transition-base);
+  outline: none;
+}
+
+.fide-search-input:focus {
+  border-color: var(--color-primary-light);
+  background: rgba(25, 40, 75, 0.95);
+  box-shadow: 0 0 20px rgba(56, 189, 248, 0.3);
+}
+
+.fide-search-icon {
+  position: absolute;
+  left: 16px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: rgba(56, 189, 248, 0.5);
+  font-size: 18px;
+  pointer-events: none;
+}
+
+.fide-switch-container {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-md);
+  cursor: pointer;
+  user-select: none;
+  font-size: var(--fs-sm);
+  color: var(--neutral-200);
+  font-weight: var(--fw-medium);
+}
+
+.fide-switch {
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 22px;
+}
+
+.fide-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.fide-slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(30, 41, 59, 0.8);
+  border: 1.5px solid rgba(56, 189, 248, 0.3);
+  transition: .3s;
+  border-radius: 34px;
+}
+
+.fide-slider:before {
+  position: absolute;
+  content: "";
+  height: 14px;
+  width: 14px;
+  left: 3px;
+  bottom: 2.5px;
+  background-color: var(--neutral-400);
+  transition: .3s;
+  border-radius: 50%;
+}
+
+.fide-switch input:checked + .fide-slider {
+  background-color: rgba(56, 189, 248, 0.2);
+  border-color: var(--color-primary-light);
+}
+
+.fide-switch input:checked + .fide-slider:before {
+  transform: translateX(20px);
+  background-color: var(--color-primary-light);
+  box-shadow: 0 0 8px var(--color-primary-light);
+}
+
+@media (max-width: 768px) {
+  .fide-top-grid {
+    grid-template-columns: 1fr;
+    gap: var(--space-sm);
+  }
+}
+
 @media (max-width: 768px) {
   .filter-row-top {
     flex-direction: column;

--- a/css/schedule.css
+++ b/css/schedule.css
@@ -679,3 +679,62 @@ td.today .day-number {
         font-size: 1.2rem;
     }
 }
+
+/* Schedule Filters */
+.schedule-filters {
+    display: flex;
+    gap: 15px;
+    margin: 20px 0;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+}
+
+.schedule-filters input,
+.schedule-filters select {
+    background: rgba(10, 25, 47, 0.7);
+    border: 1.5px solid var(--cyan-400);
+    border-radius: 8px;
+    color: var(--cyan-100);
+    padding: 10px 15px;
+    font-size: 14px;
+    outline: none;
+    transition: all 0.3s ease;
+    box-shadow: 0 0 10px rgba(0, 242, 255, 0.1);
+}
+
+.schedule-filters input::placeholder {
+    color: rgba(0, 242, 255, 0.5);
+}
+
+.schedule-filters input:focus,
+.schedule-filters select:focus {
+    border-color: var(--cyan-300);
+    box-shadow: 0 0 15px rgba(0, 242, 255, 0.3);
+}
+
+.schedule-filters input {
+    flex: 1;
+    min-width: 200px;
+    max-width: 400px;
+}
+
+.schedule-filters select {
+    min-width: 180px;
+    cursor: pointer;
+}
+
+@media (max-width: 768px) {
+    .schedule-filters {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 10px;
+    }
+    .schedule-filters input,
+    .schedule-filters select {
+        width: 100%;
+        max-width: none;
+        min-width: unset;
+    }
+}

--- a/css/schedule.css
+++ b/css/schedule.css
@@ -892,8 +892,8 @@ td.today .day-number {
     }
 }
 
-/* FIDE Style Filter System */
-.fide-top-grid {
+/* Tour Filter System */
+.tour-top-grid {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: var(--space-md);
@@ -901,12 +901,12 @@ td.today .day-number {
     width: 100%;
 }
 
-.fide-dropdown {
+.tour-dropdown {
     position: relative;
     width: 100%;
 }
 
-.fide-dropdown-btn {
+.tour-dropdown-btn {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -923,35 +923,35 @@ td.today .day-number {
     box-shadow: 0 0 10px rgba(0, 242, 255, 0.1);
 }
 
-.fide-dropdown-btn:hover {
+.tour-dropdown-btn:hover {
     background: rgba(25, 40, 75, 0.8);
     border-color: var(--cyan-300);
     box-shadow: 0 0 15px rgba(0, 242, 255, 0.2);
 }
 
-.fide-dropdown-btn-content {
+.tour-dropdown-btn-content {
     display: flex;
     align-items: center;
     gap: var(--space-md);
 }
 
-.fide-dropdown-btn-content i {
+.tour-dropdown-btn-content i {
     font-size: 20px;
     color: var(--cyan-300);
 }
 
-.fide-dropdown-arrow {
+.tour-dropdown-arrow {
     transition: transform 0.3s ease;
     font-size: 14px;
     color: var(--neutral-400);
 }
 
-.fide-dropdown.open .fide-dropdown-arrow {
+.tour-dropdown.open .tour-dropdown-arrow {
     transform: rotate(180deg);
     color: var(--cyan-300);
 }
 
-.fide-dropdown-menu {
+.tour-dropdown-menu {
     position: absolute;
     top: calc(100% + 8px);
     left: 0;
@@ -969,11 +969,11 @@ td.today .day-number {
     overflow-y: auto;
 }
 
-.fide-dropdown.open .fide-dropdown-menu {
+.tour-dropdown.open .tour-dropdown-menu {
     display: flex;
 }
 
-.fide-dropdown-menu .custom-checkbox-container {
+.tour-dropdown-menu .custom-checkbox-container {
     width: 100%;
     padding: 8px 8px 8px 34px;
     margin: 0;
@@ -981,16 +981,16 @@ td.today .day-number {
     transition: all 0.2s ease;
 }
 
-.fide-dropdown-menu .custom-checkbox-container:hover {
+.tour-dropdown-menu .custom-checkbox-container:hover {
     background: rgba(0, 242, 255, 0.1);
     color: var(--neutral-100);
 }
 
-.fide-dropdown-menu .checkmark {
+.tour-dropdown-menu .checkmark {
     left: 8px;
 }
 
-.fide-select-btn {
+.tour-select-btn {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -1015,18 +1015,18 @@ td.today .day-number {
     outline: none;
 }
 
-.fide-select-btn:hover {
+.tour-select-btn:hover {
     background: rgba(25, 40, 75, 0.8);
     border-color: var(--cyan-300);
     box-shadow: 0 0 15px rgba(0, 242, 255, 0.2);
 }
 
-.fide-select-btn option {
+.tour-select-btn option {
     background-color: rgba(12, 20, 38, 0.98);
     color: var(--neutral-100);
 }
 
-.fide-search-row {
+.tour-search-row {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -1036,13 +1036,13 @@ td.today .day-number {
     flex-wrap: wrap;
 }
 
-.fide-search-wrapper {
+.tour-search-wrapper {
     position: relative;
     flex: 1;
     min-width: 250px;
 }
 
-.fide-search-input {
+.tour-search-input {
     width: 100%;
     padding: 12px 16px 12px 42px;
     background: rgba(10, 25, 47, 0.7);
@@ -1054,13 +1054,13 @@ td.today .day-number {
     outline: none;
 }
 
-.fide-search-input:focus {
+.tour-search-input:focus {
     border-color: var(--cyan-300);
     background: rgba(25, 40, 75, 0.95);
     box-shadow: 0 0 20px rgba(0, 242, 255, 0.3);
 }
 
-.fide-search-icon {
+.tour-search-icon {
     position: absolute;
     left: 16px;
     top: 50%;
@@ -1070,7 +1070,7 @@ td.today .day-number {
     pointer-events: none;
 }
 
-.fide-switch-container {
+.tour-switch-container {
     display: inline-flex;
     align-items: center;
     gap: 10px;
@@ -1081,20 +1081,20 @@ td.today .day-number {
     font-weight: var(--fw-medium);
 }
 
-.fide-switch {
+.tour-switch {
     position: relative;
     display: inline-block;
     width: 44px;
     height: 22px;
 }
 
-.fide-switch input {
+.tour-switch input {
     opacity: 0;
     width: 0;
     height: 0;
 }
 
-.fide-slider {
+.tour-slider {
     position: absolute;
     cursor: pointer;
     top: 0;
@@ -1107,7 +1107,7 @@ td.today .day-number {
     border-radius: 34px;
 }
 
-.fide-slider:before {
+.tour-slider:before {
     position: absolute;
     content: "";
     height: 14px;
@@ -1119,20 +1119,36 @@ td.today .day-number {
     border-radius: 50%;
 }
 
-.fide-switch input:checked + .fide-slider {
+.tour-switch input:checked + .tour-slider {
     background-color: rgba(0, 242, 255, 0.2);
     border-color: var(--cyan-300);
 }
 
-.fide-switch input:checked + .fide-slider:before {
+.tour-switch input:checked + .tour-slider:before {
     transform: translateX(20px);
     background-color: var(--cyan-300);
     box-shadow: 0 0 8px var(--cyan-300);
 }
 
 @media (max-width: 768px) {
-    .fide-top-grid {
-        grid-template-columns: 1fr;
-        gap: var(--space-sm);
+    .tour-top-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 8px;
+        margin-bottom: 12px;
+    }
+    .tour-dropdown-btn,
+    .tour-select-btn {
+        padding: 10px 14px;
+        font-size: 13px;
+        border-radius: var(--border-radius-md);
+    }
+    .tour-dropdown-btn-content {
+        gap: var(--space-xs);
+    }
+    .tour-dropdown-btn-content i {
+        font-size: 18px;
+    }
+    .tour-dropdown-arrow {
+        font-size: 12px;
     }
 }

--- a/css/schedule.css
+++ b/css/schedule.css
@@ -815,6 +815,50 @@ td.today .day-number {
     align-items: flex-start;
 }
 
+/* Filter toggle button styling */
+.btn-toggle-filters {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-xs);
+    background: rgba(10, 25, 47, 0.7);
+    border: 1.5px solid var(--cyan-400);
+    border-radius: 8px;
+    color: var(--cyan-100);
+    padding: 10px 15px;
+    font-size: 14px;
+    font-weight: var(--fw-semibold);
+    cursor: pointer;
+    transition: all 0.3s ease;
+    box-shadow: 0 0 10px rgba(0, 242, 255, 0.1);
+    outline: none;
+    height: max-content;
+}
+
+.btn-toggle-filters:hover,
+.btn-toggle-filters.active {
+    background: rgba(0, 242, 255, 0.15);
+    border-color: var(--cyan-300);
+    color: var(--cyan-300);
+    box-shadow: 0 0 15px rgba(0, 242, 255, 0.4);
+    transform: translateY(-2px);
+}
+
+/* Collapsible Panel styling */
+.collapsible-panel {
+    animation: slideDown 0.3s ease-out;
+}
+
+@keyframes slideDown {
+    from {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
 .filter-label {
     font-size: 14px;
     font-weight: bold;

--- a/css/schedule.css
+++ b/css/schedule.css
@@ -725,6 +725,115 @@ td.today .day-number {
     cursor: pointer;
 }
 
+/* Custom Checkbox Container */
+.custom-checkbox-container {
+    display: inline-flex;
+    align-items: center;
+    position: relative;
+    padding-left: 28px;
+    margin-right: 15px;
+    margin-bottom: 8px;
+    cursor: pointer;
+    font-size: 14px;
+    color: var(--cyan-100);
+    user-select: none;
+    transition: all 0.2s ease;
+}
+
+.custom-checkbox-container input {
+    position: absolute;
+    opacity: 0;
+    cursor: pointer;
+    height: 0;
+    width: 0;
+}
+
+/* Checkmark box */
+.checkmark {
+    position: absolute;
+    top: 50%;
+    left: 0;
+    transform: translateY(-50%);
+    height: 18px;
+    width: 18px;
+    background-color: rgba(10, 25, 47, 0.7);
+    border: 1.5px solid var(--cyan-400);
+    border-radius: 4px;
+    box-shadow: 0 0 5px rgba(0, 242, 255, 0.1);
+    transition: all 0.2s ease;
+}
+
+/* Hover effect */
+.custom-checkbox-container:hover .checkmark {
+    border-color: var(--cyan-300);
+    box-shadow: 0 0 8px rgba(0, 242, 255, 0.3);
+}
+
+/* Checked state */
+.custom-checkbox-container input:checked ~ .checkmark {
+    background-color: rgba(0, 242, 255, 0.2);
+    border-color: var(--cyan-300);
+    box-shadow: 0 0 10px rgba(0, 242, 255, 0.5);
+}
+
+/* Checked checkmark shape */
+.checkmark:after {
+    content: "";
+    position: absolute;
+    display: none;
+}
+
+.custom-checkbox-container input:checked ~ .checkmark:after {
+    display: block;
+}
+
+.custom-checkbox-container .checkmark:after {
+    left: 5px;
+    top: 2px;
+    width: 5px;
+    height: 9px;
+    border: solid var(--cyan-300);
+    border-width: 0 2px 2px 0;
+    transform: rotate(45deg);
+}
+
+/* Layout for Filter Groups */
+.filter-row-top {
+    display: flex;
+    gap: 20px;
+    align-items: center;
+    width: 100%;
+    flex-wrap: wrap;
+    margin-bottom: 10px;
+}
+
+.filter-row-bottom {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    width: 100%;
+    align-items: flex-start;
+}
+
+.filter-label {
+    font-size: 14px;
+    font-weight: bold;
+    color: var(--cyan-300);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.checkbox-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px 12px;
+    width: 100%;
+    background: rgba(10, 25, 47, 0.3);
+    padding: 10px 15px;
+    border-radius: 8px;
+    border: 1px solid rgba(53, 201, 252, 0.2);
+}
+
 @media (max-width: 768px) {
     .schedule-filters {
         flex-direction: column;

--- a/css/schedule.css
+++ b/css/schedule.css
@@ -891,3 +891,248 @@ td.today .day-number {
         min-width: unset;
     }
 }
+
+/* FIDE Style Filter System */
+.fide-top-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: var(--space-md);
+    margin-bottom: var(--space-md);
+    width: 100%;
+}
+
+.fide-dropdown {
+    position: relative;
+    width: 100%;
+}
+
+.fide-dropdown-btn {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    padding: 14px 20px;
+    background: rgba(10, 25, 47, 0.7);
+    border: 1.5px solid var(--cyan-400);
+    border-radius: var(--border-radius-lg);
+    color: var(--cyan-100);
+    font-size: 14px;
+    font-weight: var(--fw-semibold);
+    cursor: pointer;
+    transition: all 0.3s ease;
+    box-shadow: 0 0 10px rgba(0, 242, 255, 0.1);
+}
+
+.fide-dropdown-btn:hover {
+    background: rgba(25, 40, 75, 0.8);
+    border-color: var(--cyan-300);
+    box-shadow: 0 0 15px rgba(0, 242, 255, 0.2);
+}
+
+.fide-dropdown-btn-content {
+    display: flex;
+    align-items: center;
+    gap: var(--space-md);
+}
+
+.fide-dropdown-btn-content i {
+    font-size: 20px;
+    color: var(--cyan-300);
+}
+
+.fide-dropdown-arrow {
+    transition: transform 0.3s ease;
+    font-size: 14px;
+    color: var(--neutral-400);
+}
+
+.fide-dropdown.open .fide-dropdown-arrow {
+    transform: rotate(180deg);
+    color: var(--cyan-300);
+}
+
+.fide-dropdown-menu {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 0;
+    width: 100%;
+    background: rgba(12, 20, 38, 0.98);
+    border: 1.5px solid var(--cyan-300);
+    border-radius: var(--border-radius-lg);
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5), 0 0 15px rgba(0, 242, 255, 0.2);
+    padding: 8px;
+    z-index: 150;
+    display: none;
+    flex-direction: column;
+    gap: 4px;
+    max-height: 250px;
+    overflow-y: auto;
+}
+
+.fide-dropdown.open .fide-dropdown-menu {
+    display: flex;
+}
+
+.fide-dropdown-menu .custom-checkbox-container {
+    width: 100%;
+    padding: 8px 8px 8px 34px;
+    margin: 0;
+    border-radius: var(--border-radius-md);
+    transition: all 0.2s ease;
+}
+
+.fide-dropdown-menu .custom-checkbox-container:hover {
+    background: rgba(0, 242, 255, 0.1);
+    color: var(--neutral-100);
+}
+
+.fide-dropdown-menu .checkmark {
+    left: 8px;
+}
+
+.fide-select-btn {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    padding: 14px 20px;
+    background: rgba(10, 25, 47, 0.7);
+    border: 1.5px solid var(--cyan-400);
+    border-radius: var(--border-radius-lg);
+    color: var(--cyan-100);
+    font-size: 14px;
+    font-weight: var(--fw-semibold);
+    cursor: pointer;
+    transition: all 0.3s ease;
+    box-shadow: 0 0 10px rgba(0, 242, 255, 0.1);
+    appearance: none;
+    -webkit-appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2300f2ff' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 20px center;
+    background-size: 16px;
+    padding-right: 44px;
+    outline: none;
+}
+
+.fide-select-btn:hover {
+    background: rgba(25, 40, 75, 0.8);
+    border-color: var(--cyan-300);
+    box-shadow: 0 0 15px rgba(0, 242, 255, 0.2);
+}
+
+.fide-select-btn option {
+    background-color: rgba(12, 20, 38, 0.98);
+    color: var(--neutral-100);
+}
+
+.fide-search-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    gap: 15px;
+    margin-bottom: 15px;
+    flex-wrap: wrap;
+}
+
+.fide-search-wrapper {
+    position: relative;
+    flex: 1;
+    min-width: 250px;
+}
+
+.fide-search-input {
+    width: 100%;
+    padding: 12px 16px 12px 42px;
+    background: rgba(10, 25, 47, 0.7);
+    border: 1.5px solid var(--cyan-400);
+    border-radius: var(--border-radius-lg);
+    color: var(--cyan-100);
+    font-size: 14px;
+    transition: all 0.3s ease;
+    outline: none;
+}
+
+.fide-search-input:focus {
+    border-color: var(--cyan-300);
+    background: rgba(25, 40, 75, 0.95);
+    box-shadow: 0 0 20px rgba(0, 242, 255, 0.3);
+}
+
+.fide-search-icon {
+    position: absolute;
+    left: 16px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: rgba(0, 242, 255, 0.5);
+    font-size: 18px;
+    pointer-events: none;
+}
+
+.fide-switch-container {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    cursor: pointer;
+    user-select: none;
+    font-size: 14px;
+    color: var(--neutral-200);
+    font-weight: var(--fw-medium);
+}
+
+.fide-switch {
+    position: relative;
+    display: inline-block;
+    width: 44px;
+    height: 22px;
+}
+
+.fide-switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.fide-slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(30, 41, 59, 0.8);
+    border: 1.5px solid rgba(0, 242, 255, 0.3);
+    transition: .3s;
+    border-radius: 34px;
+}
+
+.fide-slider:before {
+    position: absolute;
+    content: "";
+    height: 14px;
+    width: 14px;
+    left: 3px;
+    bottom: 2.5px;
+    background-color: var(--neutral-400);
+    transition: .3s;
+    border-radius: 50%;
+}
+
+.fide-switch input:checked + .fide-slider {
+    background-color: rgba(0, 242, 255, 0.2);
+    border-color: var(--cyan-300);
+}
+
+.fide-switch input:checked + .fide-slider:before {
+    transform: translateX(20px);
+    background-color: var(--cyan-300);
+    box-shadow: 0 0 8px var(--cyan-300);
+}
+
+@media (max-width: 768px) {
+    .fide-top-grid {
+        grid-template-columns: 1fr;
+        gap: var(--space-sm);
+    }
+}

--- a/js/aggregated-fetcher.js
+++ b/js/aggregated-fetcher.js
@@ -160,14 +160,18 @@
                 const text = await RequestManager.fetch(`${API.GIST}/${monthId}.txt`, false);
                 ids = text ? text.split('\n').filter(l => l.trim()) : [];
             }
-            if (!ids.length) return { playerScores: {}, tournaments: [] };
+            if (!ids.length) return { playerScores: {}, tournaments: [], status: 'finished' };
 
             const tourDataList = await Promise.all(ids.map(id => RequestManager.fetch(`${API.CHESS_COM}/tournament/${id}`)));
             const playerScores = {}, tournaments = [];
+            let monthStatus = 'finished';
 
             for (let i = 0; i < ids.length; i++) {
                 const data = tourDataList[i];
                 if (!data) continue;
+                const isFinished = (data.status === 'finished' || data.settings?.status === 'finished');
+                if (!isFinished) monthStatus = 'unfinished';
+
                 const rounds = data.settings?.total_rounds || data.rounds || data.total_rounds || 0;
                 let pointsMap = new Map();
                 let roundPlayersMap = new Map();
@@ -230,7 +234,7 @@
                     playerScores[u].breakdown.push({ tourName: data.name || 'Unknown', points: p.points, url: data.url });
                 });
             }
-            const result = { playerScores, tournaments };
+            const result = { playerScores, tournaments, status: monthStatus };
             Cache.set(cacheKey, result, CONFIG.CACHE_TTL.a);
             return result;
         }
@@ -318,21 +322,12 @@
                             </select>
                         </div>
 
-                        <!-- Column 2: Status/Type (Decorative/Unused) -->
-                        <div class="fide-select-container">
+                        <!-- Column 2: Status/Type -->
+                        <div class="fide-select-container" style="grid-column: span 2;">
                             <select id="cttq-status-filter" class="fide-select-btn" onchange="searchTable()">
                                 <option value="all">Tất cả trạng thái</option>
                                 <option value="finished">Đã hoàn thành</option>
-                            </select>
-                        </div>
-
-                        <!-- Column 3: Year (Decorative/Unused) -->
-                        <div class="fide-select-container">
-                            <select id="cttq-year-filter" class="fide-select-btn" onchange="searchTable()">
-                                <option value="all">Tất cả các năm</option>
-                                <option value="2026">Năm 2026</option>
-                                <option value="2025">Năm 2025</option>
-                                <option value="2024">Năm 2024</option>
+                                <option value="unfinished">Chưa hoàn thành</option>
                             </select>
                         </div>
                     </div>
@@ -413,7 +408,7 @@
                     const temp = document.createElement('tbody'); temp.innerHTML = html;
 
                     const newTr = temp.firstElementChild;
-                    const { playerScores, tournaments } = await DataProcessor.getMonthlyAggregation(m, eventType);
+                    const { playerScores, tournaments, status } = await DataProcessor.getMonthlyAggregation(m, eventType);
                     const parts = m.split('-');
                     const monthInt = parseInt(parts[0]) - 1;
                     const yearInt = parseInt(parts[1]);
@@ -422,6 +417,7 @@
                     newTr.setAttribute('data-start-time', timestamp);
                     newTr.setAttribute('data-players-count', Object.keys(playerScores).length);
                     newTr.setAttribute('data-tours-count', tournaments.length);
+                    newTr.setAttribute('data-status', status || 'finished');
 
                     skeletons[i].replaceWith(newTr);
                     document.getElementById('current-tournament').textContent = ++count;

--- a/js/aggregated-fetcher.js
+++ b/js/aggregated-fetcher.js
@@ -332,12 +332,20 @@
                         </div>
                     </div>
 
-                    <!-- FIDE style second bar (Search + Status Badge) -->
+                    <!-- FIDE style second bar (Search + Switch + Status Badge) -->
                     <div class="fide-search-row">
                         <div class="fide-search-wrapper">
                             <span class="bx bx-search fide-search-icon"></span>
                             <input type="text" id="searchInput" class="fide-search-input" placeholder="Tìm kiếm..." onkeyup="searchTable()">
                         </div>
+
+                        <label class="fide-switch-container">
+                            <span class="fide-switch">
+                                <input type="checkbox" id="premiumToggle" checked onchange="searchTable()">
+                                <span class="fide-slider"></span>
+                            </span>
+                            <span>Hiện Premium Badge</span>
+                        </label>
 
                         <div id="loading-status" class="loading-status-badge">
                             <span id="statusIcon" class="bx bx-dots-horizontal-rounded" style="color: var(--primary-warning)"></span>

--- a/js/aggregated-fetcher.js
+++ b/js/aggregated-fetcher.js
@@ -308,11 +308,11 @@
 
             container.innerHTML = `
                 <div class="filter-group-container" style="margin-bottom: 25px;">
-                    <!-- FIDE style top bar with 3 columns -->
-                    <div class="fide-top-grid">
+                    <!-- Top bar with 3 columns -->
+                    <div class="tour-top-grid">
                         <!-- Column 1: Sắp xếp -->
-                        <div class="fide-select-container">
-                            <select id="sortFilter" class="fide-select-btn" onchange="searchTable()">
+                        <div class="tour-select-container">
+                            <select id="sortFilter" class="tour-select-btn" onchange="searchTable()">
                                 <option value="date-desc">Tháng tổ chức (Mới nhất)</option>
                                 <option value="date-asc">Tháng tổ chức (Cũ nhất)</option>
                                 <option value="players-desc">Số lượng kỳ thủ (Nhiều nhất)</option>
@@ -323,8 +323,8 @@
                         </div>
 
                         <!-- Column 2: Status/Type -->
-                        <div class="fide-select-container" style="grid-column: span 2;">
-                            <select id="cttq-status-filter" class="fide-select-btn" onchange="searchTable()">
+                        <div class="tour-select-container" style="grid-column: span 2;">
+                            <select id="cttq-status-filter" class="tour-select-btn" onchange="searchTable()">
                                 <option value="all">Tất cả trạng thái</option>
                                 <option value="finished">Đã hoàn thành</option>
                                 <option value="unfinished">Chưa hoàn thành</option>
@@ -332,17 +332,17 @@
                         </div>
                     </div>
 
-                    <!-- FIDE style second bar (Search + Switch + Status Badge) -->
-                    <div class="fide-search-row">
-                        <div class="fide-search-wrapper">
-                            <span class="bx bx-search fide-search-icon"></span>
-                            <input type="text" id="searchInput" class="fide-search-input" placeholder="Tìm kiếm..." onkeyup="searchTable()">
+                    <!-- Second bar (Search + Switch + Status Badge) -->
+                    <div class="tour-search-row">
+                        <div class="tour-search-wrapper">
+                            <span class="bx bx-search tour-search-icon"></span>
+                            <input type="text" id="searchInput" class="tour-search-input" placeholder="Tìm kiếm..." onkeyup="searchTable()">
                         </div>
 
-                        <label class="fide-switch-container">
-                            <span class="fide-switch">
+                        <label class="tour-switch-container">
+                            <span class="tour-switch">
                                 <input type="checkbox" id="premiumToggle" checked onchange="searchTable()">
-                                <span class="fide-slider"></span>
+                                <span class="tour-slider"></span>
                             </span>
                             <span>Hiện Premium Badge</span>
                         </label>

--- a/js/aggregated-fetcher.js
+++ b/js/aggregated-fetcher.js
@@ -302,10 +302,33 @@
 
             if (!months.length) { container.innerHTML = '<div class="error">Không tìm thấy dữ liệu.</div>'; return; }
 
-            container.innerHTML = `<input type="text" id="searchInput" class="search-bar" onkeyup="searchTable()" placeholder="Tìm kiếm...">
-                <div id="loading-status" style="text-align: center; padding: 20px; font-size: 14px;">Đang xử lý: <span id="statusIcon" class="bx bx-dots-horizontal-rounded" style="color: var(--primary-warning)"></span> <span id="current-tournament">0</span>/${months.length} tháng</div>
+            container.innerHTML = `
+                <div class="filter-group-container">
+                    <div class="filter-row-top">
+                        <input type="text" id="searchInput" class="search-bar" onkeyup="searchTable()" placeholder="Tìm kiếm...">
+                        <div class="sort-select-wrapper">
+                            <span class="filter-label">Sắp xếp:</span>
+                            <select id="sortFilter" onchange="searchTable()">
+                                <option value="date-desc">Tháng tổ chức (Mới nhất)</option>
+                                <option value="date-asc">Tháng tổ chức (Cũ nhất)</option>
+                                <option value="players-desc">Số lượng kỳ thủ (Nhiều nhất)</option>
+                                <option value="players-asc">Số lượng kỳ thủ (Ít nhất)</option>
+                                <option value="tours-desc">Số lượng giải đấu (Nhiều nhất)</option>
+                                <option value="tours-asc">Số lượng giải đấu (Ít nhất)</option>
+                            </select>
+                        </div>
+                        <div id="loading-status" class="loading-status-badge">
+                            <span id="statusIcon" class="bx bx-dots-horizontal-rounded" style="color: var(--primary-warning)"></span>
+                            <span id="current-tournament">0</span>/${months.length} tháng
+                        </div>
+                    </div>
+                </div>
                 <div class="table"><table class="styled-table" id="tournament-results-table"><thead><tr><th class="name-tour">Tháng</th><th class="organization-day">Thống kê</th><th class="players">Kỳ thủ</th>
                 <th class="winner">🥇 Top 1</th><th class="winner">🥈 Top 2</th><th class="winner">🥉 Top 3</th><th class="winner">🎖️ Top 4</th><th class="winner">🏅 Top 5</th><th class="winner">⭐ Top 6</th></tr></thead><tbody id="tournament-tbody"><tr class="not-match" style="display: none"><td style="color: var(--color-warning)">Không tìm thấy kết quả nào!</td></tr></tbody></table></div>`;
+
+            if (typeof window.loadTournamentFiltersFromURL === 'function') {
+                window.loadTournamentFiltersFromURL();
+            }
 
             const tbody = document.getElementById('tournament-tbody');
             const skeletons = months.map(() => {
@@ -361,8 +384,24 @@
                 try {
                     const html = await Renderer.monthRow(m, eventType);
                     const temp = document.createElement('tbody'); temp.innerHTML = html;
-                    skeletons[i].replaceWith(temp.firstElementChild);
+
+                    const newTr = temp.firstElementChild;
+                    const { playerScores, tournaments } = await DataProcessor.getMonthlyAggregation(m, eventType);
+                    const parts = m.split('-');
+                    const monthInt = parseInt(parts[0]) - 1;
+                    const yearInt = parseInt(parts[1]);
+                    const timestamp = new Date(yearInt, monthInt, 1).getTime();
+
+                    newTr.setAttribute('data-start-time', timestamp);
+                    newTr.setAttribute('data-players-count', Object.keys(playerScores).length);
+                    newTr.setAttribute('data-tours-count', tournaments.length);
+
+                    skeletons[i].replaceWith(newTr);
                     document.getElementById('current-tournament').textContent = ++count;
+
+                    if (typeof window.searchTable === 'function') {
+                        window.searchTable();
+                    }
                 } catch (e) {}
             }));
 

--- a/js/aggregated-fetcher.js
+++ b/js/aggregated-fetcher.js
@@ -303,12 +303,12 @@
             if (!months.length) { container.innerHTML = '<div class="error">Không tìm thấy dữ liệu.</div>'; return; }
 
             container.innerHTML = `
-                <div class="filter-group-container">
-                    <div class="filter-row-top">
-                        <input type="text" id="searchInput" class="search-bar" onkeyup="searchTable()" placeholder="Tìm kiếm...">
-                        <div class="sort-select-wrapper">
-                            <span class="filter-label">Sắp xếp:</span>
-                            <select id="sortFilter" onchange="searchTable()">
+                <div class="filter-group-container" style="margin-bottom: 25px;">
+                    <!-- FIDE style top bar with 3 columns -->
+                    <div class="fide-top-grid">
+                        <!-- Column 1: Sắp xếp -->
+                        <div class="fide-select-container">
+                            <select id="sortFilter" class="fide-select-btn" onchange="searchTable()">
                                 <option value="date-desc">Tháng tổ chức (Mới nhất)</option>
                                 <option value="date-asc">Tháng tổ chức (Cũ nhất)</option>
                                 <option value="players-desc">Số lượng kỳ thủ (Nhiều nhất)</option>
@@ -317,6 +317,33 @@
                                 <option value="tours-asc">Số lượng giải đấu (Ít nhất)</option>
                             </select>
                         </div>
+
+                        <!-- Column 2: Status/Type (Decorative/Unused) -->
+                        <div class="fide-select-container">
+                            <select id="cttq-status-filter" class="fide-select-btn" onchange="searchTable()">
+                                <option value="all">Tất cả trạng thái</option>
+                                <option value="finished">Đã hoàn thành</option>
+                            </select>
+                        </div>
+
+                        <!-- Column 3: Year (Decorative/Unused) -->
+                        <div class="fide-select-container">
+                            <select id="cttq-year-filter" class="fide-select-btn" onchange="searchTable()">
+                                <option value="all">Tất cả các năm</option>
+                                <option value="2026">Năm 2026</option>
+                                <option value="2025">Năm 2025</option>
+                                <option value="2024">Năm 2024</option>
+                            </select>
+                        </div>
+                    </div>
+
+                    <!-- FIDE style second bar (Search + Status Badge) -->
+                    <div class="fide-search-row">
+                        <div class="fide-search-wrapper">
+                            <span class="bx bx-search fide-search-icon"></span>
+                            <input type="text" id="searchInput" class="fide-search-input" placeholder="Tìm kiếm..." onkeyup="searchTable()">
+                        </div>
+
                         <div id="loading-status" class="loading-status-badge">
                             <span id="statusIcon" class="bx bx-dots-horizontal-rounded" style="color: var(--primary-warning)"></span>
                             <span id="current-tournament">0</span>/${months.length} tháng

--- a/js/schedule.js
+++ b/js/schedule.js
@@ -74,8 +74,6 @@ function renderCalendar() {
     const searchVal = (document.getElementById('schedule-search')?.value || '').toLowerCase().trim();
     const onlyPrize = document.getElementById('schedule-prize-filter')?.checked || false;
     const checkedTypes = Array.from(document.querySelectorAll('#schedule-type-group input[type="checkbox"]:checked')).map(cb => cb.value);
-    const organizerVal = document.getElementById('schedule-organizer-filter')?.value || 'all';
-    const dayVal = document.getElementById('schedule-day-filter')?.value || 'all';
 
     // Update header
     const monthNames = ['Tháng 1', 'Tháng 2', 'Tháng 3', 'Tháng 4', 'Tháng 5', 'Tháng 6',
@@ -171,34 +169,7 @@ function renderCalendar() {
                     // Match Type
                     const matchesType = checkedTypes.includes(tournament.eventType);
 
-                    // Match Organizer
-                    let matchesOrganizer = true;
-                    if (organizerVal !== 'all') {
-                        const organizer = (tournament.organizer || '').toLowerCase();
-                        const tType = tournament.eventType;
-                        if (organizerVal === 'tvlt') {
-                            matchesOrganizer = tType === 'tvlt' || organizer.includes('tvlt') || organizer.includes('thí vua') || organizer.includes('clb');
-                        } else if (organizerVal === '1wl') {
-                            matchesOrganizer = tType === '1wl' || organizer.includes('owl') || organizer.includes('one world') || organizer.includes('league');
-                        } else {
-                            matchesOrganizer = !(tType === 'tvlt' || organizer.includes('tvlt') || organizer.includes('thí vua') || organizer.includes('clb') || tType === '1wl' || organizer.includes('owl') || organizer.includes('one world'));
-                        }
-                    }
-
-                    // Match Day
-                    let matchesDay = true;
-                    if (dayVal !== 'all') {
-                        const tDate = new Date(tournament.startTime);
-                        const day = tDate.getDay();
-                        const isWeekend = (day === 0 || day === 6);
-                        if (dayVal === 'weekday') {
-                            matchesDay = !isWeekend;
-                        } else {
-                            matchesDay = isWeekend;
-                        }
-                    }
-
-                    if (matchesSearch && matchesPrize && matchesType && matchesOrganizer && matchesDay) {
+                    if (matchesSearch && matchesPrize && matchesType) {
                         const icon = document.createElement('span');
                         icon.className = 'event-icon';
 
@@ -333,11 +304,7 @@ function openModal(tournament) {
     let newsUrl = "";
     let resultUrl = "";
 
-    if (tournamentType === "1wl") {
-        newsUrl = "https://chess.com/clubs/forum/view/multi-club-arena-seasons-2026";
-        bannerUrl = "https://images.chesscomfiles.com/uploads/v1/blog/1036746.ca7cfdc5.668x375o.1821c106decb.jpg";
-        resultUrl = "https://chess.com/blog/OneWorldLeague";
-    } else if (["cttq", "tvlt", "cbtt", "dttv"].includes(tournamentType)) {
+    if (["cttq", "tvlt", "cbtt", "dttv"].includes(tournamentType)) {
         resultUrl = `/events/tournaments/${tournamentType}`;
         const eventInfo = {
             "tvlt": "/events/tvlt-thi-vua-lay-tot",
@@ -356,6 +323,7 @@ function openModal(tournament) {
     } else {
         resultUrl = `https://chess.com/clubs/events/thi-vua-lay-tot-tungjohn-playing-chess?cid=325849&ref_id=89365835&type=${tournamentType}`;
         const bannerDefault = {
+            "1wl": "https://images.chesscomfiles.com/uploads/v1/blog/1036746.ca7cfdc5.668x375o.1821c106decb.jpg",
             "club-arena": "https://images.chesscomfiles.com/uploads/v1/images_users/tiny_mce/VN-SenJin/phpjs58p98gfqbbaDynSFJ.png",
             "multi-club-arena": "https://images.chesscomfiles.com/uploads/v1/images_users/tiny_mce/VN-SenJin/php4oaq7r23q7n79I3kRE6.png",
             "swiss": "https://images.chesscomfiles.com/uploads/v1/images_users/tiny_mce/VN-SenJin/phpt9ef43prdg6f80YfkLo.png",
@@ -363,6 +331,7 @@ function openModal(tournament) {
             "daily": "https://images.chesscomfiles.com/uploads/v1/chess_term/f1e3ca50-b739-11ea-a14a-a1c9be904231.1fc2467a.630x354o.73dd2efd0681.png"
         };
         const eventDetails = {
+            "1wl": "https://chess.com/blog/OneWorldLeague",
             "club-arena": "https://support.chess.com/articles/8562889-what-are-arena-tournaments",
             "swiss": "https://chess.com/terms/swiss-chess",
             "vote": "https://support.chess.com/articles/8614177-how-do-i-play-vote-chess",

--- a/js/schedule.js
+++ b/js/schedule.js
@@ -15,6 +15,7 @@ const API_URL = 'https://script.google.com/macros/s/AKfycbzMq-aqPlXihBjjC62ykxba
  * Initialize calendar on DOM content loaded.
  */
 window.addEventListener('DOMContentLoaded', () => {
+    loadFiltersFromURL();
     loadTournaments();
 });
 
@@ -195,9 +196,76 @@ function renderCalendar() {
 }
 
 /**
+ * Loads filter states from URL query parameters.
+ */
+function loadFiltersFromURL() {
+    const params = new URLSearchParams(window.location.search);
+
+    // 1. Search filter
+    const searchVal = params.get('search');
+    const searchInput = document.getElementById('schedule-search');
+    if (searchInput && searchVal !== null) {
+        searchInput.value = searchVal;
+    }
+
+    // 2. Prize filter (1 = prize, 0 = all)
+    const prizeVal = params.get('prize');
+    const prizeCheckbox = document.getElementById('schedule-prize-filter');
+    if (prizeCheckbox && prizeVal !== null) {
+        prizeCheckbox.checked = (prizeVal === '1');
+    }
+
+    // 3. Category/Type filter joined by space or plus
+    const tcVal = params.get('tc');
+    if (tcVal !== null) {
+        const selectedTypes = tcVal.toLowerCase().split(/[\s+]+/);
+        const checkboxes = document.querySelectorAll('#schedule-type-group input[type="checkbox"]');
+        checkboxes.forEach(cb => {
+            cb.checked = selectedTypes.includes(cb.value.toLowerCase());
+        });
+    }
+}
+
+/**
+ * Saves current filter states to the URL query parameters.
+ */
+function saveFiltersToURL() {
+    const params = new URLSearchParams();
+
+    // 1. Search filter
+    const searchVal = (document.getElementById('schedule-search')?.value || '').trim();
+    if (searchVal) {
+        params.set('search', searchVal);
+    }
+
+    // 2. Prize filter
+    const prizeCheckbox = document.getElementById('schedule-prize-filter');
+    if (prizeCheckbox && prizeCheckbox.checked) {
+        params.set('prize', '1');
+    } else {
+        params.set('prize', '0');
+    }
+
+    // 3. Category/Type filter
+    const checkedTypes = Array.from(document.querySelectorAll('#schedule-type-group input[type="checkbox"]:checked')).map(cb => cb.value);
+    const allTypes = Array.from(document.querySelectorAll('#schedule-type-group input[type="checkbox"]')).map(cb => cb.value);
+
+    // If not all are checked, serialize the active ones joined by space
+    if (checkedTypes.length < allTypes.length) {
+        params.set('tc', checkedTypes.join(' '));
+    }
+
+    // Update URL without page reload
+    const newQuery = params.toString();
+    const newURL = window.location.pathname + (newQuery ? '?' + newQuery : '');
+    window.history.replaceState(null, '', newURL);
+}
+
+/**
  * Filter schedule function triggered by input/select changes.
  */
 function filterSchedule() {
+    saveFiltersToURL();
     renderCalendar();
 }
 

--- a/js/schedule.js
+++ b/js/schedule.js
@@ -50,7 +50,7 @@ async function loadTournaments() {
         } else {
             document.getElementById('calendar-wrapper').style.display = 'block';
             const filtersDiv = document.getElementById('schedule-filters');
-            if (filtersDiv) filtersDiv.style.display = 'flex';
+            if (filtersDiv) filtersDiv.style.display = 'block';
             renderCalendar();
         }
     } catch (error) {
@@ -74,6 +74,8 @@ function renderCalendar() {
     const searchVal = (document.getElementById('schedule-search')?.value || '').toLowerCase().trim();
     const onlyPrize = document.getElementById('schedule-prize-filter')?.checked || false;
     const checkedTypes = Array.from(document.querySelectorAll('#schedule-type-group input[type="checkbox"]:checked')).map(cb => cb.value);
+    const organizerVal = document.getElementById('schedule-organizer-filter')?.value || 'all';
+    const dayVal = document.getElementById('schedule-day-filter')?.value || 'all';
 
     // Update header
     const monthNames = ['Tháng 1', 'Tháng 2', 'Tháng 3', 'Tháng 4', 'Tháng 5', 'Tháng 6',
@@ -169,7 +171,34 @@ function renderCalendar() {
                     // Match Type
                     const matchesType = checkedTypes.includes(tournament.eventType);
 
-                    if (matchesSearch && matchesPrize && matchesType) {
+                    // Match Organizer
+                    let matchesOrganizer = true;
+                    if (organizerVal !== 'all') {
+                        const organizer = (tournament.organizer || '').toLowerCase();
+                        const tType = tournament.eventType;
+                        if (organizerVal === 'tvlt') {
+                            matchesOrganizer = tType === 'tvlt' || organizer.includes('tvlt') || organizer.includes('thí vua') || organizer.includes('clb');
+                        } else if (organizerVal === '1wl') {
+                            matchesOrganizer = tType === '1wl' || organizer.includes('owl') || organizer.includes('one world') || organizer.includes('league');
+                        } else {
+                            matchesOrganizer = !(tType === 'tvlt' || organizer.includes('tvlt') || organizer.includes('thí vua') || organizer.includes('clb') || tType === '1wl' || organizer.includes('owl') || organizer.includes('one world'));
+                        }
+                    }
+
+                    // Match Day
+                    let matchesDay = true;
+                    if (dayVal !== 'all') {
+                        const tDate = new Date(tournament.startTime);
+                        const day = tDate.getDay();
+                        const isWeekend = (day === 0 || day === 6);
+                        if (dayVal === 'weekday') {
+                            matchesDay = !isWeekend;
+                        } else {
+                            matchesDay = isWeekend;
+                        }
+                    }
+
+                    if (matchesSearch && matchesPrize && matchesType && matchesOrganizer && matchesDay) {
                         const icon = document.createElement('span');
                         icon.className = 'event-icon';
 
@@ -262,21 +291,25 @@ function saveFiltersToURL() {
 }
 
 /**
- * Toggles the visibility of the advanced collapsible filter panel.
+ * Toggles visibility of dropdown boxes.
  */
-function toggleScheduleFilters() {
-    const panel = document.getElementById('schedule-collapsible-panel');
-    const btn = document.getElementById('schedule-toggle-btn');
-    if (panel) {
-        if (panel.style.display === 'none') {
-            panel.style.display = 'flex';
-            btn.classList.add('active');
-        } else {
-            panel.style.display = 'none';
-            btn.classList.remove('active');
-        }
-    }
+function toggleDropdown(id) {
+    const el = document.getElementById(id);
+    if (!el) return;
+
+    document.querySelectorAll('.fide-dropdown').forEach(d => {
+        if (d.id !== id) d.classList.remove('open');
+    });
+
+    el.classList.toggle('open');
 }
+
+// Close dropdowns on click outside
+window.addEventListener('click', (e) => {
+    if (!e.target.closest('.fide-dropdown')) {
+        document.querySelectorAll('.fide-dropdown').forEach(d => d.classList.remove('open'));
+    }
+});
 
 /**
  * Filter schedule function triggered by input/select changes.
@@ -287,7 +320,7 @@ function filterSchedule() {
 }
 
 window.filterSchedule = filterSchedule;
-window.toggleScheduleFilters = toggleScheduleFilters;
+window.toggleDropdown = toggleDropdown;
 
 /**
  * Opens the event detail modal with tournament information.

--- a/js/schedule.js
+++ b/js/schedule.js
@@ -71,8 +71,8 @@ function renderCalendar() {
 
     // Get filter values
     const searchVal = (document.getElementById('schedule-search')?.value || '').toLowerCase().trim();
-    const prizeVal = document.getElementById('schedule-prize-filter')?.value || 'all';
-    const typeVal = document.getElementById('schedule-type-filter')?.value || 'all';
+    const onlyPrize = document.getElementById('schedule-prize-filter')?.checked || false;
+    const checkedTypes = Array.from(document.querySelectorAll('#schedule-type-group input[type="checkbox"]:checked')).map(cb => cb.value);
 
     // Update header
     const monthNames = ['Tháng 1', 'Tháng 2', 'Tháng 3', 'Tháng 4', 'Tháng 5', 'Tháng 6',
@@ -160,17 +160,13 @@ function renderCalendar() {
 
                     // Match Prize
                     let matchesPrize = true;
-                    if (prizeVal === 'prize') {
+                    if (onlyPrize) {
                         const prize = (tournament.prize || '').toLowerCase().trim();
                         matchesPrize = (prize !== '' && prize !== 'giao lưu' && prize !== 'không' && prize !== 'không có');
                     }
 
                     // Match Type
-                    let matchesType = true;
-                    if (typeVal !== 'all') {
-                        const tType = tournament.eventType;
-                        matchesType = (tType === typeVal);
-                    }
+                    const matchesType = checkedTypes.includes(tournament.eventType);
 
                     if (matchesSearch && matchesPrize && matchesType) {
                         const icon = document.createElement('span');

--- a/js/schedule.js
+++ b/js/schedule.js
@@ -48,6 +48,8 @@ async function loadTournaments() {
             document.getElementById('empty').style.display = 'block';
         } else {
             document.getElementById('calendar-wrapper').style.display = 'block';
+            const filtersDiv = document.getElementById('schedule-filters');
+            if (filtersDiv) filtersDiv.style.display = 'flex';
             renderCalendar();
         }
     } catch (error) {
@@ -66,6 +68,11 @@ function renderCalendar() {
     const today = new Date();
     const year = today.getFullYear();
     const month = today.getMonth();
+
+    // Get filter values
+    const searchVal = (document.getElementById('schedule-search')?.value || '').toLowerCase().trim();
+    const prizeVal = document.getElementById('schedule-prize-filter')?.value || 'all';
+    const typeVal = document.getElementById('schedule-type-filter')?.value || 'all';
 
     // Update header
     const monthNames = ['Tháng 1', 'Tháng 2', 'Tháng 3', 'Tháng 4', 'Tháng 5', 'Tháng 6',
@@ -147,19 +154,39 @@ function renderCalendar() {
                 });
 
                 dayTournaments.forEach(tournament => {
-                    const icon = document.createElement('span');
-                    icon.className = 'event-icon';
+                    // Match Search
+                    const eventName = (tournament.eventName || '').toLowerCase();
+                    const matchesSearch = !searchVal || eventName.includes(searchVal);
 
-                    const img = document.createElement('img');
-                    img.src = tournament.logo || 'https://chess.com/bundles/web/images/image-default.445cb543.svg';
-                    img.title = tournament.eventName || 'Tournament';
-                    img.onclick = (e) => {
-                        e.stopPropagation();
-                        openModal(tournament);
-                    };
+                    // Match Prize
+                    let matchesPrize = true;
+                    if (prizeVal === 'prize') {
+                        const prize = (tournament.prize || '').toLowerCase().trim();
+                        matchesPrize = (prize !== '' && prize !== 'giao lưu' && prize !== 'không' && prize !== 'không có');
+                    }
 
-                    icon.appendChild(img);
-                    eventsDiv.appendChild(icon);
+                    // Match Type
+                    let matchesType = true;
+                    if (typeVal !== 'all') {
+                        const tType = tournament.eventType;
+                        matchesType = (tType === typeVal);
+                    }
+
+                    if (matchesSearch && matchesPrize && matchesType) {
+                        const icon = document.createElement('span');
+                        icon.className = 'event-icon';
+
+                        const img = document.createElement('img');
+                        img.src = tournament.logo || 'https://chess.com/bundles/web/images/image-default.445cb543.svg';
+                        img.title = tournament.eventName || 'Tournament';
+                        img.onclick = (e) => {
+                            e.stopPropagation();
+                            openModal(tournament);
+                        };
+
+                        icon.appendChild(img);
+                        eventsDiv.appendChild(icon);
+                    }
                 });
             }
 
@@ -170,6 +197,15 @@ function renderCalendar() {
         tbody.appendChild(tr);
     }
 }
+
+/**
+ * Filter schedule function triggered by input/select changes.
+ */
+function filterSchedule() {
+    renderCalendar();
+}
+
+window.filterSchedule = filterSchedule;
 
 /**
  * Opens the event detail modal with tournament information.

--- a/js/schedule.js
+++ b/js/schedule.js
@@ -264,21 +264,20 @@ function saveFiltersToURL() {
 /**
  * Toggles visibility of dropdown boxes.
  */
-function toggleDropdown(id) {
+function toggleTourDropdown(id) {
     const el = document.getElementById(id);
     if (!el) return;
 
-    document.querySelectorAll('.fide-dropdown').forEach(d => {
+    document.querySelectorAll('.tour-dropdown').forEach(d => {
         if (d.id !== id) d.classList.remove('open');
     });
 
     el.classList.toggle('open');
 }
 
-// Close dropdowns on click outside
 window.addEventListener('click', (e) => {
-    if (!e.target.closest('.fide-dropdown')) {
-        document.querySelectorAll('.fide-dropdown').forEach(d => d.classList.remove('open'));
+    if (!e.target.closest('.tour-dropdown')) {
+        document.querySelectorAll('.tour-dropdown').forEach(d => d.classList.remove('open'));
     }
 });
 
@@ -291,7 +290,7 @@ function filterSchedule() {
 }
 
 window.filterSchedule = filterSchedule;
-window.toggleDropdown = toggleDropdown;
+window.toggleTourDropdown = toggleTourDropdown;
 
 /**
  * Opens the event detail modal with tournament information.

--- a/js/schedule.js
+++ b/js/schedule.js
@@ -262,6 +262,23 @@ function saveFiltersToURL() {
 }
 
 /**
+ * Toggles the visibility of the advanced collapsible filter panel.
+ */
+function toggleScheduleFilters() {
+    const panel = document.getElementById('schedule-collapsible-panel');
+    const btn = document.getElementById('schedule-toggle-btn');
+    if (panel) {
+        if (panel.style.display === 'none') {
+            panel.style.display = 'flex';
+            btn.classList.add('active');
+        } else {
+            panel.style.display = 'none';
+            btn.classList.remove('active');
+        }
+    }
+}
+
+/**
  * Filter schedule function triggered by input/select changes.
  */
 function filterSchedule() {
@@ -270,6 +287,7 @@ function filterSchedule() {
 }
 
 window.filterSchedule = filterSchedule;
+window.toggleScheduleFilters = toggleScheduleFilters;
 
 /**
  * Opens the event detail modal with tournament information.

--- a/js/search-events.js
+++ b/js/search-events.js
@@ -28,8 +28,8 @@ window.searchTable = debounce(function() {
     if (!table) return;
 
     const sortFilterSelect = document.getElementById('sortFilter');
-    const timeClassSelect = document.getElementById('timeClassFilter');
-    const variantSelect = document.getElementById('variantFilter');
+    const timeClassGroup = document.getElementById('timeclass-checkbox-group');
+    const variantGroup = document.getElementById('variant-checkbox-group');
 
     const tbody = document.getElementById('tournament-tbody') || table.querySelector('tbody');
     if (!tbody) return;
@@ -64,8 +64,14 @@ window.searchTable = debounce(function() {
     const rows = tbody.getElementsByTagName('tr');
     let matched = false;
 
-    const timeClassVal = timeClassSelect ? timeClassSelect.value : 'all';
-    const variantVal = variantSelect ? variantSelect.value : 'all';
+    // Read checkbox lists
+    const checkedTimeClasses = timeClassGroup
+        ? Array.from(timeClassGroup.querySelectorAll('input[type="checkbox"]:checked')).map(cb => cb.value)
+        : null;
+
+    const checkedVariants = variantGroup
+        ? Array.from(variantGroup.querySelectorAll('input[type="checkbox"]:checked')).map(cb => cb.value)
+        : null;
 
     // Iterate through all table rows, skipping 'not-match'
     for (let i = 0; i < rows.length; i++) {
@@ -94,7 +100,7 @@ window.searchTable = debounce(function() {
 
         // 2. Check time class filter
         let timeClassMatch = true;
-        if (timeClassVal !== 'all') {
+        if (checkedTimeClasses !== null) {
             const rowTimeClass = row.getAttribute('data-time-class');
             if (rowTimeClass) {
                 // Map lightning/bullet -> bullet, rapid/standard -> rapid, blitz -> blitz, classical -> classical
@@ -102,7 +108,7 @@ window.searchTable = debounce(function() {
                 if (rowMapped === 'lightning') rowMapped = 'bullet';
                 if (rowMapped === 'standard') rowMapped = 'rapid';
 
-                if (rowMapped !== timeClassVal.toLowerCase()) {
+                if (!checkedTimeClasses.includes(rowMapped)) {
                     timeClassMatch = false;
                 }
             } else {
@@ -112,13 +118,13 @@ window.searchTable = debounce(function() {
 
         // 3. Check variant filter
         let variantMatch = true;
-        if (variantVal !== 'all') {
+        if (checkedVariants !== null) {
             const rowVariant = row.getAttribute('data-variant');
             if (rowVariant) {
                 let rowMapped = rowVariant.toLowerCase();
                 if (rowMapped === 'chess') rowMapped = 'standard';
 
-                if (rowMapped !== variantVal.toLowerCase()) {
+                if (!checkedVariants.includes(rowMapped)) {
                     variantMatch = false;
                 }
             } else {

--- a/js/search-events.js
+++ b/js/search-events.js
@@ -57,6 +57,17 @@ window.loadTournamentFiltersFromURL = function() {
             cb.checked = selectedVars.includes(cb.value.toLowerCase());
         });
     }
+
+    // 5. Format filter joined by space or plus
+    const formatVal = params.get('format');
+    const formatGroup = document.getElementById('format-checkbox-group');
+    if (formatGroup && formatVal !== null) {
+        const selectedFormats = formatVal.toLowerCase().split(/[\s+]+/);
+        const checkboxes = formatGroup.querySelectorAll('input[type="checkbox"]');
+        checkboxes.forEach(cb => {
+            cb.checked = selectedFormats.includes(cb.value.toLowerCase());
+        });
+    }
 };
 
 /**
@@ -98,6 +109,16 @@ window.saveTournamentFiltersToURL = function() {
         }
     }
 
+    // 5. Format filter
+    const formatGroup = document.getElementById('format-checkbox-group');
+    if (formatGroup) {
+        const checked = Array.from(formatGroup.querySelectorAll('input[type="checkbox"]:checked')).map(cb => cb.value);
+        const all = Array.from(formatGroup.querySelectorAll('input[type="checkbox"]')).map(cb => cb.value);
+        if (checked.length < all.length) {
+            params.set('format', checked.join(' '));
+        }
+    }
+
     // Update URL without page reload
     const newQuery = params.toString();
     const newURL = window.location.pathname + (newQuery ? '?' + newQuery : '');
@@ -123,6 +144,7 @@ window.searchTable = debounce(function() {
     const sortFilterSelect = document.getElementById('sortFilter');
     const timeClassGroup = document.getElementById('timeclass-checkbox-group');
     const variantGroup = document.getElementById('variant-checkbox-group');
+    const formatGroup = document.getElementById('format-checkbox-group');
 
     const tbody = document.getElementById('tournament-tbody') || table.querySelector('tbody');
     if (!tbody) return;
@@ -168,6 +190,10 @@ window.searchTable = debounce(function() {
 
     const checkedVariants = variantGroup
         ? Array.from(variantGroup.querySelectorAll('input[type="checkbox"]:checked')).map(cb => cb.value)
+        : null;
+
+    const checkedFormats = formatGroup
+        ? Array.from(formatGroup.querySelectorAll('input[type="checkbox"]:checked')).map(cb => cb.value)
         : null;
 
     // Iterate through all table rows, skipping 'not-match'
@@ -229,7 +255,31 @@ window.searchTable = debounce(function() {
             }
         }
 
-        const finalMatch = textMatch && timeClassMatch && variantMatch;
+        // 4. Check format filter
+        let formatMatch = true;
+        if (checkedFormats !== null) {
+            const rowFormat = row.getAttribute('data-format');
+            if (rowFormat) {
+                if (!checkedFormats.includes(rowFormat.toLowerCase())) {
+                    formatMatch = false;
+                }
+            } else {
+                formatMatch = false;
+            }
+        }
+
+        // 5. Check CTTQ status filter
+        const cttqStatusSelect = document.getElementById('cttq-status-filter');
+        const cttqStatusVal = cttqStatusSelect ? cttqStatusSelect.value : 'all';
+        let cttqStatusMatch = true;
+        if (cttqStatusVal !== 'all') {
+            const rowStatus = row.getAttribute('data-status');
+            if (rowStatus && rowStatus !== cttqStatusVal) {
+                cttqStatusMatch = false;
+            }
+        }
+
+        const finalMatch = textMatch && timeClassMatch && variantMatch && formatMatch && cttqStatusMatch;
         if (finalMatch) {
             row.style.display = '';
             matched = true;

--- a/js/search-events.js
+++ b/js/search-events.js
@@ -328,13 +328,13 @@ window.searchTable = debounce(function() {
 }, 100);
 
 /**
- * Toggles visibility of FIDE dropdown boxes.
+ * Toggles visibility of tour dropdown boxes.
  */
-window.toggleDropdown = function(id) {
+window.toggleTourDropdown = function(id) {
     const el = document.getElementById(id);
     if (!el) return;
 
-    document.querySelectorAll('.fide-dropdown').forEach(d => {
+    document.querySelectorAll('.tour-dropdown').forEach(d => {
         if (d.id !== id) d.classList.remove('open');
     });
 
@@ -343,7 +343,7 @@ window.toggleDropdown = function(id) {
 
 // Close dropdowns on click outside
 window.addEventListener('click', (e) => {
-    if (!e.target.closest('.fide-dropdown')) {
-        document.querySelectorAll('.fide-dropdown').forEach(d => d.classList.remove('open'));
+    if (!e.target.closest('.tour-dropdown')) {
+        document.querySelectorAll('.tour-dropdown').forEach(d => d.classList.remove('open'));
     }
 });

--- a/js/search-events.js
+++ b/js/search-events.js
@@ -17,11 +17,104 @@ function debounce(func, wait) {
 }
 
 /**
+ * Loads tournament filter states from URL query parameters.
+ */
+window.loadTournamentFiltersFromURL = function() {
+    const params = new URLSearchParams(window.location.search);
+
+    // 1. Search filter
+    const searchVal = params.get('search');
+    const searchInput = document.getElementById('searchInput');
+    if (searchInput && searchVal !== null) {
+        searchInput.value = searchVal;
+    }
+
+    // 2. Sort filter
+    const sortVal = params.get('sort');
+    const sortSelect = document.getElementById('sortFilter');
+    if (sortSelect && sortVal !== null) {
+        sortSelect.value = sortVal;
+    }
+
+    // 3. Time Class (speed) filter joined by space or plus
+    const speedVal = params.get('speed');
+    const timeClassGroup = document.getElementById('timeclass-checkbox-group');
+    if (timeClassGroup && speedVal !== null) {
+        const selectedSpeeds = speedVal.toLowerCase().split(/[\s+]+/);
+        const checkboxes = timeClassGroup.querySelectorAll('input[type="checkbox"]');
+        checkboxes.forEach(cb => {
+            cb.checked = selectedSpeeds.includes(cb.value.toLowerCase());
+        });
+    }
+
+    // 4. Variant (var) filter joined by space or plus
+    const varVal = params.get('var');
+    const variantGroup = document.getElementById('variant-checkbox-group');
+    if (variantGroup && varVal !== null) {
+        const selectedVars = varVal.toLowerCase().split(/[\s+]+/);
+        const checkboxes = variantGroup.querySelectorAll('input[type="checkbox"]');
+        checkboxes.forEach(cb => {
+            cb.checked = selectedVars.includes(cb.value.toLowerCase());
+        });
+    }
+};
+
+/**
+ * Saves tournament filter states to URL query parameters.
+ */
+window.saveTournamentFiltersToURL = function() {
+    const params = new URLSearchParams();
+
+    // 1. Search filter
+    const searchInput = document.getElementById('searchInput');
+    const searchVal = (searchInput?.value || '').trim();
+    if (searchVal) {
+        params.set('search', searchVal);
+    }
+
+    // 2. Sort filter
+    const sortSelect = document.getElementById('sortFilter');
+    if (sortSelect && sortSelect.value !== 'date-desc') {
+        params.set('sort', sortSelect.value);
+    }
+
+    // 3. Time Class (speed) filter
+    const timeClassGroup = document.getElementById('timeclass-checkbox-group');
+    if (timeClassGroup) {
+        const checked = Array.from(timeClassGroup.querySelectorAll('input[type="checkbox"]:checked')).map(cb => cb.value);
+        const all = Array.from(timeClassGroup.querySelectorAll('input[type="checkbox"]')).map(cb => cb.value);
+        if (checked.length < all.length) {
+            params.set('speed', checked.join(' '));
+        }
+    }
+
+    // 4. Variant (var) filter
+    const variantGroup = document.getElementById('variant-checkbox-group');
+    if (variantGroup) {
+        const checked = Array.from(variantGroup.querySelectorAll('input[type="checkbox"]:checked')).map(cb => cb.value);
+        const all = Array.from(variantGroup.querySelectorAll('input[type="checkbox"]')).map(cb => cb.value);
+        if (checked.length < all.length) {
+            params.set('var', checked.join(' '));
+        }
+    }
+
+    // Update URL without page reload
+    const newQuery = params.toString();
+    const newURL = window.location.pathname + (newQuery ? '?' + newQuery : '');
+    window.history.replaceState(null, '', newURL);
+};
+
+/**
  * Filters and sorts the events table based on search input and dropdown selectors.
  */
 window.searchTable = debounce(function() {
     const input = document.getElementById('searchInput');
     if (!input) return;
+
+    // Save state to URL query parameters
+    if (typeof window.saveTournamentFiltersToURL === 'function') {
+        window.saveTournamentFiltersToURL();
+    }
 
     const filter = input.value.toUpperCase();
     const table = document.querySelector('.styled-table');

--- a/js/search-events.js
+++ b/js/search-events.js
@@ -245,18 +245,22 @@ window.searchTable = debounce(function() {
 }, 100);
 
 /**
- * Toggles the visibility of the advanced collapsible tournament filter panel.
+ * Toggles visibility of FIDE dropdown boxes.
  */
-window.toggleTournamentFilters = function() {
-    const panel = document.getElementById('tournament-collapsible-panel');
-    const btn = document.getElementById('tournament-toggle-btn');
-    if (panel) {
-        if (panel.style.display === 'none') {
-            panel.style.display = 'flex';
-            btn.classList.add('active');
-        } else {
-            panel.style.display = 'none';
-            btn.classList.remove('active');
-        }
-    }
+window.toggleDropdown = function(id) {
+    const el = document.getElementById(id);
+    if (!el) return;
+
+    document.querySelectorAll('.fide-dropdown').forEach(d => {
+        if (d.id !== id) d.classList.remove('open');
+    });
+
+    el.classList.toggle('open');
 };
+
+// Close dropdowns on click outside
+window.addEventListener('click', (e) => {
+    if (!e.target.closest('.fide-dropdown')) {
+        document.querySelectorAll('.fide-dropdown').forEach(d => d.classList.remove('open'));
+    }
+});

--- a/js/search-events.js
+++ b/js/search-events.js
@@ -17,8 +17,7 @@ function debounce(func, wait) {
 }
 
 /**
- * Filters the events table based on the user's search input.
- * Searches across all columns and toggles row visibility.
+ * Filters and sorts the events table based on search input and dropdown selectors.
  */
 window.searchTable = debounce(function() {
     const input = document.getElementById('searchInput');
@@ -26,29 +25,118 @@ window.searchTable = debounce(function() {
 
     const filter = input.value.toUpperCase();
     const table = document.querySelector('.styled-table');
-
     if (!table) return;
 
-    const rows = table.getElementsByTagName('tr');
+    const sortFilterSelect = document.getElementById('sortFilter');
+    const timeClassSelect = document.getElementById('timeClassFilter');
+    const variantSelect = document.getElementById('variantFilter');
+
+    const tbody = document.getElementById('tournament-tbody') || table.querySelector('tbody');
+    if (!tbody) return;
+
+    // 1. Sort the table rows first if sortFilter is present and there are loaded rows
+    if (sortFilterSelect) {
+        const sortVal = sortFilterSelect.value;
+        const allRows = Array.from(tbody.querySelectorAll('tr'));
+        const loadedRows = allRows.filter(r => r.getAttribute('data-start-time') !== null && !r.classList.contains('not-match'));
+        const skeletonRows = allRows.filter(r => r.classList.contains('skeleton-row'));
+        const notMatchRow = allRows.find(r => r.classList.contains('not-match'));
+
+        loadedRows.sort((a, b) => {
+            if (sortVal === 'date-desc') {
+                return (parseInt(b.getAttribute('data-start-time')) || 0) - (parseInt(a.getAttribute('data-start-time')) || 0);
+            } else if (sortVal === 'date-asc') {
+                return (parseInt(a.getAttribute('data-start-time')) || 0) - (parseInt(b.getAttribute('data-start-time')) || 0);
+            } else if (sortVal === 'players-desc') {
+                return (parseInt(b.getAttribute('data-players-count')) || 0) - (parseInt(a.getAttribute('data-players-count')) || 0);
+            } else if (sortVal === 'players-asc') {
+                return (parseInt(a.getAttribute('data-players-count')) || 0) - (parseInt(b.getAttribute('data-players-count')) || 0);
+            }
+            return 0;
+        });
+
+        // Re-append to order them on screen
+        loadedRows.forEach(row => tbody.appendChild(row));
+        skeletonRows.forEach(row => tbody.appendChild(row));
+        if (notMatchRow) tbody.appendChild(notMatchRow);
+    }
+
+    const rows = tbody.getElementsByTagName('tr');
     let matched = false;
 
-    // Iterate through all table rows, skipping the header & alert
-    for (let i = 2; i < rows.length; i++) {
-        const cells = rows[i].getElementsByTagName('td');
-        let match = false;
+    const timeClassVal = timeClassSelect ? timeClassSelect.value : 'all';
+    const variantVal = variantSelect ? variantSelect.value : 'all';
 
-        // Check if any cell in the row matches the search filter
-        for (let j = 0; j < cells.length; j++) {
-            const cell = cells[j];
-            if (cell && cell.textContent.toUpperCase().indexOf(filter) > -1) {
-                match = true;
-                matched = true;
-                break;
+    // Iterate through all table rows, skipping 'not-match'
+    for (let i = 0; i < rows.length; i++) {
+        const row = rows[i];
+        if (row.classList.contains('not-match')) continue;
+        if (row.classList.contains('skeleton-row')) {
+            row.style.display = '';
+            continue;
+        }
+
+        const cells = row.getElementsByTagName('td');
+
+        // 1. Check text search
+        let textMatch = false;
+        if (!filter) {
+            textMatch = true;
+        } else {
+            for (let j = 0; j < cells.length; j++) {
+                const cell = cells[j];
+                if (cell && cell.textContent.toUpperCase().indexOf(filter) > -1) {
+                    textMatch = true;
+                    break;
+                }
             }
         }
 
-        // Toggle row visibility based on match result
-        rows[i].style.display = match ? '' : 'none';
+        // 2. Check time class filter
+        let timeClassMatch = true;
+        if (timeClassVal !== 'all') {
+            const rowTimeClass = row.getAttribute('data-time-class');
+            if (rowTimeClass) {
+                // Map lightning/bullet -> bullet, rapid/standard -> rapid, blitz -> blitz, classical -> classical
+                let rowMapped = rowTimeClass.toLowerCase();
+                if (rowMapped === 'lightning') rowMapped = 'bullet';
+                if (rowMapped === 'standard') rowMapped = 'rapid';
+
+                if (rowMapped !== timeClassVal.toLowerCase()) {
+                    timeClassMatch = false;
+                }
+            } else {
+                timeClassMatch = false;
+            }
+        }
+
+        // 3. Check variant filter
+        let variantMatch = true;
+        if (variantVal !== 'all') {
+            const rowVariant = row.getAttribute('data-variant');
+            if (rowVariant) {
+                let rowMapped = rowVariant.toLowerCase();
+                if (rowMapped === 'chess') rowMapped = 'standard';
+
+                if (rowMapped !== variantVal.toLowerCase()) {
+                    variantMatch = false;
+                }
+            } else {
+                variantMatch = false;
+            }
+        }
+
+        const finalMatch = textMatch && timeClassMatch && variantMatch;
+        if (finalMatch) {
+            row.style.display = '';
+            matched = true;
+        } else {
+            row.style.display = 'none';
+        }
     }
-    table.querySelector('.not-match').style.display = matched ? 'none' : '';
+
+    const notMatchRow = tbody.querySelector('.not-match');
+    if (notMatchRow) {
+        notMatchRow.style.display = matched ? 'none' : '';
+    }
 }, 100);

--- a/js/search-events.js
+++ b/js/search-events.js
@@ -239,3 +239,20 @@ window.searchTable = debounce(function() {
         notMatchRow.style.display = matched ? 'none' : '';
     }
 }, 100);
+
+/**
+ * Toggles the visibility of the advanced collapsible tournament filter panel.
+ */
+window.toggleTournamentFilters = function() {
+    const panel = document.getElementById('tournament-collapsible-panel');
+    const btn = document.getElementById('tournament-toggle-btn');
+    if (panel) {
+        if (panel.style.display === 'none') {
+            panel.style.display = 'flex';
+            btn.classList.add('active');
+        } else {
+            panel.style.display = 'none';
+            btn.classList.remove('active');
+        }
+    }
+};

--- a/js/search-events.js
+++ b/js/search-events.js
@@ -68,6 +68,13 @@ window.loadTournamentFiltersFromURL = function() {
             cb.checked = selectedFormats.includes(cb.value.toLowerCase());
         });
     }
+
+    // 6. Premium Toggle
+    const premiumVal = params.get('premium');
+    const premiumToggle = document.getElementById('premiumToggle');
+    if (premiumToggle && premiumVal !== null) {
+        premiumToggle.checked = (premiumVal !== '0');
+    }
 };
 
 /**
@@ -119,10 +126,31 @@ window.saveTournamentFiltersToURL = function() {
         }
     }
 
+    // 6. Premium Toggle
+    const premiumToggle = document.getElementById('premiumToggle');
+    if (premiumToggle && !premiumToggle.checked) {
+        params.set('premium', '0');
+    }
+
     // Update URL without page reload
     const newQuery = params.toString();
     const newURL = window.location.pathname + (newQuery ? '?' + newQuery : '');
     window.history.replaceState(null, '', newURL);
+};
+
+/**
+ * Toggles the visibility of Premium user badges inside tbody.
+ */
+window.togglePremium = function() {
+    const checked = document.getElementById('premiumToggle')?.checked ?? true;
+    const tbody = document.getElementById('tournament-tbody');
+    if (tbody) {
+        if (checked) {
+            tbody.classList.remove('hide-premium');
+        } else {
+            tbody.classList.add('hide-premium');
+        }
+    }
 };
 
 /**
@@ -131,6 +159,11 @@ window.saveTournamentFiltersToURL = function() {
 window.searchTable = debounce(function() {
     const input = document.getElementById('searchInput');
     if (!input) return;
+
+    // Toggle Premium Badges class on the table body
+    if (typeof window.togglePremium === 'function') {
+        window.togglePremium();
+    }
 
     // Save state to URL query parameters
     if (typeof window.saveTournamentFiltersToURL === 'function') {

--- a/js/search-events.js
+++ b/js/search-events.js
@@ -144,6 +144,10 @@ window.searchTable = debounce(function() {
                 return (parseInt(b.getAttribute('data-players-count')) || 0) - (parseInt(a.getAttribute('data-players-count')) || 0);
             } else if (sortVal === 'players-asc') {
                 return (parseInt(a.getAttribute('data-players-count')) || 0) - (parseInt(b.getAttribute('data-players-count')) || 0);
+            } else if (sortVal === 'tours-desc') {
+                return (parseInt(b.getAttribute('data-tours-count')) || 0) - (parseInt(a.getAttribute('data-tours-count')) || 0);
+            } else if (sortVal === 'tours-asc') {
+                return (parseInt(a.getAttribute('data-tours-count')) || 0) - (parseInt(b.getAttribute('data-tours-count')) || 0);
             }
             return 0;
         });

--- a/js/tournament-fetcher.js
+++ b/js/tournament-fetcher.js
@@ -189,13 +189,16 @@
                             <option value="players-asc">Kỳ thủ tham gia (Ít nhất)</option>
                         </select>
                     </div>
+                    <button type="button" id="tournament-toggle-btn" class="btn-toggle-filters" onclick="toggleTournamentFilters()">
+                        <span class="bx bx-filter-alt"></span> Bộ lọc
+                    </button>
                     <div id="loading-status" class="loading-status-badge">
                         <span id="statusIcon" class="bx bx-dots-horizontal-rounded" style="color:var(--primary-warning)"></span>
                         <span id="current-tournament">0</span>/${ids.length} giải
                     </div>
                 </div>
 
-                <div class="filter-checkboxes-section">
+                <div class="filter-checkboxes-section collapsible-panel" id="tournament-collapsible-panel" style="display: none;">
                     <div class="filter-checkbox-group">
                         <span class="filter-label">Thể lệ (Tốc độ):</span>
                         <div class="checkbox-group" id="timeclass-checkbox-group">

--- a/js/tournament-fetcher.js
+++ b/js/tournament-fetcher.js
@@ -189,6 +189,10 @@
                             <option value="players-asc">Kỳ thủ tham gia (Ít nhất)</option>
                         </select>
                     </div>
+                    <div id="loading-status" class="loading-status-badge">
+                        <span id="statusIcon" class="bx bx-dots-horizontal-rounded" style="color:var(--primary-warning)"></span>
+                        <span id="current-tournament">0</span>/${ids.length} giải
+                    </div>
                 </div>
 
                 <div class="filter-checkboxes-section">
@@ -249,7 +253,6 @@
                     </div>
                 </div>
             </div>
-            <div id="loading-status" style="text-align:center;padding:20px;font-size:14px">Đang hiển thị: <span id="statusIcon" class="bx bx-dots-horizontal-rounded" style="color:var(--primary-warning)"></span> <span id="current-tournament">0</span>/${ids.length} giải đấu</div>
             <div class="table"><table class="styled-table" id="tournament-results-table"><thead><tr><th class="name-tour">Giải đấu</th><th class="organization-day">Thời gian bắt đầu</th><th class="rules">Thể lệ</th><th class="players">Kỳ thủ</th>
             <th class="winner">🥇 Top 1</th><th class="winner">🥈 Top 2</th><th class="winner">🥉 Top 3</th><th class="winner">🎖️ Top 4</th><th class="winner">🏅 Top 5</th><th class="winner">⭐ Top 6</th></tr></thead><tbody id="tournament-tbody"><tr class="not-match" style="display:none"><td style="color:var(--color-warning)">Không tìm thấy kết quả nào!</td></tr></tbody></table></div><br><br><hr>`;
 

--- a/js/tournament-fetcher.js
+++ b/js/tournament-fetcher.js
@@ -253,6 +253,10 @@
             <div class="table"><table class="styled-table" id="tournament-results-table"><thead><tr><th class="name-tour">Giải đấu</th><th class="organization-day">Thời gian bắt đầu</th><th class="rules">Thể lệ</th><th class="players">Kỳ thủ</th>
             <th class="winner">🥇 Top 1</th><th class="winner">🥈 Top 2</th><th class="winner">🥉 Top 3</th><th class="winner">🎖️ Top 4</th><th class="winner">🏅 Top 5</th><th class="winner">⭐ Top 6</th></tr></thead><tbody id="tournament-tbody"><tr class="not-match" style="display:none"><td style="color:var(--color-warning)">Không tìm thấy kết quả nào!</td></tr></tbody></table></div><br><br><hr>`;
 
+        if (typeof window.loadTournamentFiltersFromURL === 'function') {
+            window.loadTournamentFiltersFromURL();
+        }
+
         const tbody = document.getElementById('tournament-tbody');
         const skeletons = ids.map(() => {
             const tr = document.createElement('tr'); tr.className = 'skeleton-row';

--- a/js/tournament-fetcher.js
+++ b/js/tournament-fetcher.js
@@ -176,7 +176,35 @@
         const ids = txt ? txt.split('\n').filter(l => l.trim()) : [];
         if (!ids.length) { el.innerHTML = '<div class="error">Không tìm thấy giải đấu.</div>'; return; }
 
-        el.innerHTML = `<input type="text" id="searchInput" class="search-bar" onkeyup="searchTable()" placeholder="Tìm kiếm...">
+        el.innerHTML = `
+            <div class="filter-group-container">
+                <input type="text" id="searchInput" class="search-bar" onkeyup="searchTable()" placeholder="Tìm kiếm tên giải hoặc kỳ thủ...">
+                <div class="select-filters">
+                    <select id="sortFilter" onchange="searchTable()">
+                        <option value="date-desc">Ngày tổ chức (Mới nhất)</option>
+                        <option value="date-asc">Ngày tổ chức (Cũ nhất)</option>
+                        <option value="players-desc">Kỳ thủ tham gia (Nhiều nhất)</option>
+                        <option value="players-asc">Kỳ thủ tham gia (Ít nhất)</option>
+                    </select>
+                    <select id="timeClassFilter" onchange="searchTable()">
+                        <option value="all">Tất cả tốc độ</option>
+                        <option value="bullet">Bullet</option>
+                        <option value="blitz">Blitz</option>
+                        <option value="rapid">Rapid</option>
+                        <option value="classical">Classical</option>
+                    </select>
+                    <select id="variantFilter" onchange="searchTable()">
+                        <option value="all">Tất cả biến thể</option>
+                        <option value="standard">Cờ tiêu chuẩn</option>
+                        <option value="chess960">Chess960</option>
+                        <option value="crazyhouse">Crazyhouse</option>
+                        <option value="bughouse">Bughouse</option>
+                        <option value="kingofthehill">King of the Hill</option>
+                        <option value="threecheck">3 Chiếu</option>
+                        <option value="custom">Custom</option>
+                    </select>
+                </div>
+            </div>
             <div id="loading-status" style="text-align:center;padding:20px;font-size:14px">Đang hiển thị: <span id="statusIcon" class="bx bx-dots-horizontal-rounded" style="color:var(--primary-warning)"></span> <span id="current-tournament">0</span>/${ids.length} giải đấu</div>
             <div class="table"><table class="styled-table" id="tournament-results-table"><thead><tr><th class="name-tour">Giải đấu</th><th class="organization-day">Thời gian bắt đầu</th><th class="rules">Thể lệ</th><th class="players">Kỳ thủ</th>
             <th class="winner">🥇 Top 1</th><th class="winner">🥈 Top 2</th><th class="winner">🥉 Top 3</th><th class="winner">🎖️ Top 4</th><th class="winner">🏅 Top 5</th><th class="winner">⭐ Top 6</th></tr></thead><tbody id="tournament-tbody"><tr class="not-match" style="display:none"><td style="color:var(--color-warning)">Không tìm thấy kết quả nào!</td></tr></tbody></table></div><br><br><hr>`;
@@ -233,8 +261,17 @@
 
                 for (let i = 0; i < CONFIG.MAX_PLAYERS; i++) row += await renderPlayer(top[i]?.u, top[i]?.pts || 0);
 
-                skeletons[idx].innerHTML = row; skeletons[idx].className = '';
+                skeletons[idx].innerHTML = row;
+                skeletons[idx].setAttribute('data-start-time', data.start_time || data.startTime || 0);
+                skeletons[idx].setAttribute('data-players-count', data.settings?.registered_user_count || data.players_registered || data.players?.length || 0);
+                skeletons[idx].setAttribute('data-time-class', data.settings?.time_class || data.time_class || 'classical');
+                skeletons[idx].setAttribute('data-variant', v.toLowerCase());
+                skeletons[idx].className = '';
                 document.getElementById('current-tournament').textContent = ++success;
+
+                if (typeof window.searchTable === 'function') {
+                    window.searchTable();
+                }
             } catch (e) {}
         }));
 

--- a/js/tournament-fetcher.js
+++ b/js/tournament-fetcher.js
@@ -180,36 +180,34 @@
             <div class="filter-group-container" style="margin-bottom: 25px;">
                 <!-- Top bar with 4 columns -->
                 <div class="tour-top-grid">
-                    <!-- Column 1: Multi-Select Speed Dropdown -->
                     <div class="tour-dropdown" id="tournament-speed-dropdown">
                         <div class="tour-dropdown-btn" onclick="toggleTourDropdown('tournament-speed-dropdown')">
                             <div class="tour-dropdown-btn-content">
                                 <i class="bx bx-time"></i>
-                                <span>Thể lệ (Tốc độ)</span>
+                                <span>Thể lệ</span>
                             </div>
                             <span class="bx bx-chevron-down tour-dropdown-arrow"></span>
                         </div>
                         <div class="tour-dropdown-menu" id="timeclass-checkbox-group">
                             <label class="custom-checkbox-container">
                                 <input type="checkbox" value="bullet" checked onchange="searchTable()">
-                                <span class="checkmark"></span> Bullet
+                                <span class="checkmark"></span> Bullet (Cờ Siêu chớp)
                             </label>
                             <label class="custom-checkbox-container">
                                 <input type="checkbox" value="blitz" checked onchange="searchTable()">
-                                <span class="checkmark"></span> Blitz
+                                <span class="checkmark"></span> Blitz (Cờ chớp)
                             </label>
                             <label class="custom-checkbox-container">
                                 <input type="checkbox" value="rapid" checked onchange="searchTable()">
-                                <span class="checkmark"></span> Rapid
+                                <span class="checkmark"></span> Rapid (Cờ Nhanh)
                             </label>
                             <label class="custom-checkbox-container">
                                 <input type="checkbox" value="classical" checked onchange="searchTable()">
-                                <span class="checkmark"></span> Classical
+                                <span class="checkmark"></span> Classical (Cờ chậm)
                             </label>
                         </div>
                     </div>
 
-                    <!-- Column 2: Multi-Select Variant Dropdown -->
                     <div class="tour-dropdown" id="tournament-variant-dropdown">
                         <div class="tour-dropdown-btn" onclick="toggleTourDropdown('tournament-variant-dropdown')">
                             <div class="tour-dropdown-btn-content">
@@ -250,7 +248,6 @@
                         </div>
                     </div>
 
-                    <!-- Column 3: Multi-Select Format Dropdown -->
                     <div class="tour-dropdown" id="tournament-format-dropdown">
                         <div class="tour-dropdown-btn" onclick="toggleTourDropdown('tournament-format-dropdown')">
                             <div class="tour-dropdown-btn-content">
@@ -271,7 +268,6 @@
                         </div>
                     </div>
 
-                    <!-- Column 4: Sắp xếp -->
                     <div class="tour-select-container">
                         <select id="sortFilter" class="tour-select-btn" onchange="searchTable()">
                             <option value="date-desc">Ngày tổ chức (Mới nhất)</option>

--- a/js/tournament-fetcher.js
+++ b/js/tournament-fetcher.js
@@ -282,12 +282,20 @@
                     </div>
                 </div>
 
-                <!-- FIDE style second bar (Search + Status Badge) -->
+                <!-- FIDE style second bar (Search + Switch + Status Badge) -->
                 <div class="fide-search-row">
                     <div class="fide-search-wrapper">
                         <span class="bx bx-search fide-search-icon"></span>
                         <input type="text" id="searchInput" class="fide-search-input" placeholder="Tìm kiếm tên giải hoặc kỳ thủ..." onkeyup="searchTable()">
                     </div>
+
+                    <label class="fide-switch-container">
+                        <span class="fide-switch">
+                            <input type="checkbox" id="premiumToggle" checked onchange="searchTable()">
+                            <span class="fide-slider"></span>
+                        </span>
+                        <span>Hiện Premium Badge</span>
+                    </label>
 
                     <div id="loading-status" class="loading-status-badge">
                         <span id="statusIcon" class="bx bx-dots-horizontal-rounded" style="color:var(--primary-warning)"></span>

--- a/js/tournament-fetcher.js
+++ b/js/tournament-fetcher.js
@@ -177,31 +177,19 @@
         if (!ids.length) { el.innerHTML = '<div class="error">Không tìm thấy giải đấu.</div>'; return; }
 
         el.innerHTML = `
-            <div class="filter-group-container">
-                <div class="filter-row-top">
-                    <input type="text" id="searchInput" class="search-bar" onkeyup="searchTable()" placeholder="Tìm kiếm tên giải hoặc kỳ thủ...">
-                    <div class="sort-select-wrapper">
-                        <span class="filter-label">Sắp xếp:</span>
-                        <select id="sortFilter" onchange="searchTable()">
-                            <option value="date-desc">Ngày tổ chức (Mới nhất)</option>
-                            <option value="date-asc">Ngày tổ chức (Cũ nhất)</option>
-                            <option value="players-desc">Kỳ thủ tham gia (Nhiều nhất)</option>
-                            <option value="players-asc">Kỳ thủ tham gia (Ít nhất)</option>
-                        </select>
-                    </div>
-                    <button type="button" id="tournament-toggle-btn" class="btn-toggle-filters" onclick="toggleTournamentFilters()">
-                        <span class="bx bx-filter-alt"></span> Bộ lọc
-                    </button>
-                    <div id="loading-status" class="loading-status-badge">
-                        <span id="statusIcon" class="bx bx-dots-horizontal-rounded" style="color:var(--primary-warning)"></span>
-                        <span id="current-tournament">0</span>/${ids.length} giải
-                    </div>
-                </div>
-
-                <div class="filter-checkboxes-section collapsible-panel" id="tournament-collapsible-panel" style="display: none;">
-                    <div class="filter-checkbox-group">
-                        <span class="filter-label">Thể lệ (Tốc độ):</span>
-                        <div class="checkbox-group" id="timeclass-checkbox-group">
+            <div class="filter-group-container" style="margin-bottom: 25px;">
+                <!-- FIDE style top bar with 3 columns -->
+                <div class="fide-top-grid">
+                    <!-- Column 1: Multi-Select Speed Dropdown -->
+                    <div class="fide-dropdown" id="tournament-speed-dropdown">
+                        <div class="fide-dropdown-btn" onclick="toggleDropdown('tournament-speed-dropdown')">
+                            <div class="fide-dropdown-btn-content">
+                                <i class="bx bx-time"></i>
+                                <span>Thể lệ (Tốc độ)</span>
+                            </div>
+                            <span class="bx bx-chevron-down fide-dropdown-arrow"></span>
+                        </div>
+                        <div class="fide-dropdown-menu" id="timeclass-checkbox-group">
                             <label class="custom-checkbox-container">
                                 <input type="checkbox" value="bullet" checked onchange="searchTable()">
                                 <span class="checkmark"></span> Bullet
@@ -221,9 +209,16 @@
                         </div>
                     </div>
 
-                    <div class="filter-checkbox-group">
-                        <span class="filter-label">Biến thể:</span>
-                        <div class="checkbox-group" id="variant-checkbox-group">
+                    <!-- Column 2: Multi-Select Variant Dropdown -->
+                    <div class="fide-dropdown" id="tournament-variant-dropdown">
+                        <div class="fide-dropdown-btn" onclick="toggleDropdown('tournament-variant-dropdown')">
+                            <div class="fide-dropdown-btn-content">
+                                <i class="bx bxs-category"></i>
+                                <span>Biến thể</span>
+                            </div>
+                            <span class="bx bx-chevron-down fide-dropdown-arrow"></span>
+                        </div>
+                        <div class="fide-dropdown-menu" id="variant-checkbox-group">
                             <label class="custom-checkbox-container">
                                 <input type="checkbox" value="standard" checked onchange="searchTable()">
                                 <span class="checkmark"></span> Cờ tiêu chuẩn
@@ -253,6 +248,29 @@
                                 <span class="checkmark"></span> Custom
                             </label>
                         </div>
+                    </div>
+
+                    <!-- Column 3: Sắp xếp -->
+                    <div class="fide-select-container">
+                        <select id="sortFilter" class="fide-select-btn" onchange="searchTable()">
+                            <option value="date-desc">Ngày tổ chức (Mới nhất)</option>
+                            <option value="date-asc">Ngày tổ chức (Cũ nhất)</option>
+                            <option value="players-desc">Kỳ thủ tham gia (Nhiều nhất)</option>
+                            <option value="players-asc">Kỳ thủ tham gia (Ít nhất)</option>
+                        </select>
+                    </div>
+                </div>
+
+                <!-- FIDE style second bar (Search + Status Badge) -->
+                <div class="fide-search-row">
+                    <div class="fide-search-wrapper">
+                        <span class="bx bx-search fide-search-icon"></span>
+                        <input type="text" id="searchInput" class="fide-search-input" placeholder="Tìm kiếm tên giải hoặc kỳ thủ..." onkeyup="searchTable()">
+                    </div>
+
+                    <div id="loading-status" class="loading-status-badge">
+                        <span id="statusIcon" class="bx bx-dots-horizontal-rounded" style="color:var(--primary-warning)"></span>
+                        <span id="current-tournament">0</span>/${ids.length} giải
                     </div>
                 </div>
             </div>

--- a/js/tournament-fetcher.js
+++ b/js/tournament-fetcher.js
@@ -178,7 +178,7 @@
 
         el.innerHTML = `
             <div class="filter-group-container" style="margin-bottom: 25px;">
-                <!-- FIDE style top bar with 3 columns -->
+                <!-- FIDE style top bar with 4 columns -->
                 <div class="fide-top-grid">
                     <!-- Column 1: Multi-Select Speed Dropdown -->
                     <div class="fide-dropdown" id="tournament-speed-dropdown">
@@ -250,7 +250,28 @@
                         </div>
                     </div>
 
-                    <!-- Column 3: Sắp xếp -->
+                    <!-- Column 3: Multi-Select Format Dropdown -->
+                    <div class="fide-dropdown" id="tournament-format-dropdown">
+                        <div class="fide-dropdown-btn" onclick="toggleDropdown('tournament-format-dropdown')">
+                            <div class="fide-dropdown-btn-content">
+                                <i class="bx bx-git-commit"></i>
+                                <span>Thể thức</span>
+                            </div>
+                            <span class="bx bx-chevron-down fide-dropdown-arrow"></span>
+                        </div>
+                        <div class="fide-dropdown-menu" id="format-checkbox-group">
+                            <label class="custom-checkbox-container">
+                                <input type="checkbox" value="swiss" checked onchange="searchTable()">
+                                <span class="checkmark"></span> Hệ Thụy Sĩ (Swiss)
+                            </label>
+                            <label class="custom-checkbox-container">
+                                <input type="checkbox" value="arena" checked onchange="searchTable()">
+                                <span class="checkmark"></span> Đấu trường Arena
+                            </label>
+                        </div>
+                    </div>
+
+                    <!-- Column 4: Sắp xếp -->
                     <div class="fide-select-container">
                         <select id="sortFilter" class="fide-select-btn" onchange="searchTable()">
                             <option value="date-desc">Ngày tổ chức (Mới nhất)</option>
@@ -338,6 +359,7 @@
                 skeletons[idx].setAttribute('data-players-count', data.settings?.registered_user_count || data.players_registered || data.players?.length || 0);
                 skeletons[idx].setAttribute('data-time-class', data.settings?.time_class || data.time_class || 'classical');
                 skeletons[idx].setAttribute('data-variant', v.toLowerCase());
+                skeletons[idx].setAttribute('data-format', rds === 1 ? 'arena' : 'swiss');
                 skeletons[idx].className = '';
                 document.getElementById('current-tournament').textContent = ++success;
 

--- a/js/tournament-fetcher.js
+++ b/js/tournament-fetcher.js
@@ -178,18 +178,18 @@
 
         el.innerHTML = `
             <div class="filter-group-container" style="margin-bottom: 25px;">
-                <!-- FIDE style top bar with 4 columns -->
-                <div class="fide-top-grid">
+                <!-- Top bar with 4 columns -->
+                <div class="tour-top-grid">
                     <!-- Column 1: Multi-Select Speed Dropdown -->
-                    <div class="fide-dropdown" id="tournament-speed-dropdown">
-                        <div class="fide-dropdown-btn" onclick="toggleDropdown('tournament-speed-dropdown')">
-                            <div class="fide-dropdown-btn-content">
+                    <div class="tour-dropdown" id="tournament-speed-dropdown">
+                        <div class="tour-dropdown-btn" onclick="toggleTourDropdown('tournament-speed-dropdown')">
+                            <div class="tour-dropdown-btn-content">
                                 <i class="bx bx-time"></i>
                                 <span>Thể lệ (Tốc độ)</span>
                             </div>
-                            <span class="bx bx-chevron-down fide-dropdown-arrow"></span>
+                            <span class="bx bx-chevron-down tour-dropdown-arrow"></span>
                         </div>
-                        <div class="fide-dropdown-menu" id="timeclass-checkbox-group">
+                        <div class="tour-dropdown-menu" id="timeclass-checkbox-group">
                             <label class="custom-checkbox-container">
                                 <input type="checkbox" value="bullet" checked onchange="searchTable()">
                                 <span class="checkmark"></span> Bullet
@@ -210,15 +210,15 @@
                     </div>
 
                     <!-- Column 2: Multi-Select Variant Dropdown -->
-                    <div class="fide-dropdown" id="tournament-variant-dropdown">
-                        <div class="fide-dropdown-btn" onclick="toggleDropdown('tournament-variant-dropdown')">
-                            <div class="fide-dropdown-btn-content">
+                    <div class="tour-dropdown" id="tournament-variant-dropdown">
+                        <div class="tour-dropdown-btn" onclick="toggleTourDropdown('tournament-variant-dropdown')">
+                            <div class="tour-dropdown-btn-content">
                                 <i class="bx bxs-category"></i>
                                 <span>Biến thể</span>
                             </div>
-                            <span class="bx bx-chevron-down fide-dropdown-arrow"></span>
+                            <span class="bx bx-chevron-down tour-dropdown-arrow"></span>
                         </div>
-                        <div class="fide-dropdown-menu" id="variant-checkbox-group">
+                        <div class="tour-dropdown-menu" id="variant-checkbox-group">
                             <label class="custom-checkbox-container">
                                 <input type="checkbox" value="standard" checked onchange="searchTable()">
                                 <span class="checkmark"></span> Cờ tiêu chuẩn
@@ -251,15 +251,15 @@
                     </div>
 
                     <!-- Column 3: Multi-Select Format Dropdown -->
-                    <div class="fide-dropdown" id="tournament-format-dropdown">
-                        <div class="fide-dropdown-btn" onclick="toggleDropdown('tournament-format-dropdown')">
-                            <div class="fide-dropdown-btn-content">
+                    <div class="tour-dropdown" id="tournament-format-dropdown">
+                        <div class="tour-dropdown-btn" onclick="toggleTourDropdown('tournament-format-dropdown')">
+                            <div class="tour-dropdown-btn-content">
                                 <i class="bx bx-git-commit"></i>
                                 <span>Thể thức</span>
                             </div>
-                            <span class="bx bx-chevron-down fide-dropdown-arrow"></span>
+                            <span class="bx bx-chevron-down tour-dropdown-arrow"></span>
                         </div>
-                        <div class="fide-dropdown-menu" id="format-checkbox-group">
+                        <div class="tour-dropdown-menu" id="format-checkbox-group">
                             <label class="custom-checkbox-container">
                                 <input type="checkbox" value="swiss" checked onchange="searchTable()">
                                 <span class="checkmark"></span> Hệ Thụy Sĩ (Swiss)
@@ -272,8 +272,8 @@
                     </div>
 
                     <!-- Column 4: Sắp xếp -->
-                    <div class="fide-select-container">
-                        <select id="sortFilter" class="fide-select-btn" onchange="searchTable()">
+                    <div class="tour-select-container">
+                        <select id="sortFilter" class="tour-select-btn" onchange="searchTable()">
                             <option value="date-desc">Ngày tổ chức (Mới nhất)</option>
                             <option value="date-asc">Ngày tổ chức (Cũ nhất)</option>
                             <option value="players-desc">Kỳ thủ tham gia (Nhiều nhất)</option>
@@ -282,17 +282,17 @@
                     </div>
                 </div>
 
-                <!-- FIDE style second bar (Search + Switch + Status Badge) -->
-                <div class="fide-search-row">
-                    <div class="fide-search-wrapper">
-                        <span class="bx bx-search fide-search-icon"></span>
-                        <input type="text" id="searchInput" class="fide-search-input" placeholder="Tìm kiếm tên giải hoặc kỳ thủ..." onkeyup="searchTable()">
+                <!-- Second bar (Search + Switch + Status Badge) -->
+                <div class="tour-search-row">
+                    <div class="tour-search-wrapper">
+                        <span class="bx bx-search tour-search-icon"></span>
+                        <input type="text" id="searchInput" class="tour-search-input" placeholder="Tìm kiếm tên giải hoặc kỳ thủ..." onkeyup="searchTable()">
                     </div>
 
-                    <label class="fide-switch-container">
-                        <span class="fide-switch">
+                    <label class="tour-switch-container">
+                        <span class="tour-switch">
                             <input type="checkbox" id="premiumToggle" checked onchange="searchTable()">
-                            <span class="fide-slider"></span>
+                            <span class="tour-slider"></span>
                         </span>
                         <span>Hiện Premium Badge</span>
                     </label>

--- a/js/tournament-fetcher.js
+++ b/js/tournament-fetcher.js
@@ -211,7 +211,7 @@
                     <div class="tour-dropdown" id="tournament-variant-dropdown">
                         <div class="tour-dropdown-btn" onclick="toggleTourDropdown('tournament-variant-dropdown')">
                             <div class="tour-dropdown-btn-content">
-                                <i class="bx bxs-category"></i>
+                                <i class="bx bxs-chess"></i>
                                 <span>Biến thể</span>
                             </div>
                             <span class="bx bx-chevron-down tour-dropdown-arrow"></span>
@@ -235,7 +235,7 @@
                             </label>
                             <label class="custom-checkbox-container">
                                 <input type="checkbox" value="kingofthehill" checked onchange="searchTable()">
-                                <span class="checkmark"></span> KOTH
+                                <span class="checkmark"></span> King of the hill
                             </label>
                             <label class="custom-checkbox-container">
                                 <input type="checkbox" value="threecheck" checked onchange="searchTable()">
@@ -243,7 +243,7 @@
                             </label>
                             <label class="custom-checkbox-container">
                                 <input type="checkbox" value="custom" checked onchange="searchTable()">
-                                <span class="checkmark"></span> Custom
+                                <span class="checkmark"></span> Custom Position
                             </label>
                         </div>
                     </div>
@@ -251,7 +251,7 @@
                     <div class="tour-dropdown" id="tournament-format-dropdown">
                         <div class="tour-dropdown-btn" onclick="toggleTourDropdown('tournament-format-dropdown')">
                             <div class="tour-dropdown-btn-content">
-                                <i class="bx bx-git-commit"></i>
+                                <i class="bx bx-medal"></i>
                                 <span>Thể thức</span>
                             </div>
                             <span class="bx bx-chevron-down tour-dropdown-arrow"></span>

--- a/js/tournament-fetcher.js
+++ b/js/tournament-fetcher.js
@@ -178,31 +178,75 @@
 
         el.innerHTML = `
             <div class="filter-group-container">
-                <input type="text" id="searchInput" class="search-bar" onkeyup="searchTable()" placeholder="Tìm kiếm tên giải hoặc kỳ thủ...">
-                <div class="select-filters">
-                    <select id="sortFilter" onchange="searchTable()">
-                        <option value="date-desc">Ngày tổ chức (Mới nhất)</option>
-                        <option value="date-asc">Ngày tổ chức (Cũ nhất)</option>
-                        <option value="players-desc">Kỳ thủ tham gia (Nhiều nhất)</option>
-                        <option value="players-asc">Kỳ thủ tham gia (Ít nhất)</option>
-                    </select>
-                    <select id="timeClassFilter" onchange="searchTable()">
-                        <option value="all">Tất cả tốc độ</option>
-                        <option value="bullet">Bullet</option>
-                        <option value="blitz">Blitz</option>
-                        <option value="rapid">Rapid</option>
-                        <option value="classical">Classical</option>
-                    </select>
-                    <select id="variantFilter" onchange="searchTable()">
-                        <option value="all">Tất cả biến thể</option>
-                        <option value="standard">Cờ tiêu chuẩn</option>
-                        <option value="chess960">Chess960</option>
-                        <option value="crazyhouse">Crazyhouse</option>
-                        <option value="bughouse">Bughouse</option>
-                        <option value="kingofthehill">King of the Hill</option>
-                        <option value="threecheck">3 Chiếu</option>
-                        <option value="custom">Custom</option>
-                    </select>
+                <div class="filter-row-top">
+                    <input type="text" id="searchInput" class="search-bar" onkeyup="searchTable()" placeholder="Tìm kiếm tên giải hoặc kỳ thủ...">
+                    <div class="sort-select-wrapper">
+                        <span class="filter-label">Sắp xếp:</span>
+                        <select id="sortFilter" onchange="searchTable()">
+                            <option value="date-desc">Ngày tổ chức (Mới nhất)</option>
+                            <option value="date-asc">Ngày tổ chức (Cũ nhất)</option>
+                            <option value="players-desc">Kỳ thủ tham gia (Nhiều nhất)</option>
+                            <option value="players-asc">Kỳ thủ tham gia (Ít nhất)</option>
+                        </select>
+                    </div>
+                </div>
+
+                <div class="filter-checkboxes-section">
+                    <div class="filter-checkbox-group">
+                        <span class="filter-label">Thể lệ (Tốc độ):</span>
+                        <div class="checkbox-group" id="timeclass-checkbox-group">
+                            <label class="custom-checkbox-container">
+                                <input type="checkbox" value="bullet" checked onchange="searchTable()">
+                                <span class="checkmark"></span> Bullet
+                            </label>
+                            <label class="custom-checkbox-container">
+                                <input type="checkbox" value="blitz" checked onchange="searchTable()">
+                                <span class="checkmark"></span> Blitz
+                            </label>
+                            <label class="custom-checkbox-container">
+                                <input type="checkbox" value="rapid" checked onchange="searchTable()">
+                                <span class="checkmark"></span> Rapid
+                            </label>
+                            <label class="custom-checkbox-container">
+                                <input type="checkbox" value="classical" checked onchange="searchTable()">
+                                <span class="checkmark"></span> Classical
+                            </label>
+                        </div>
+                    </div>
+
+                    <div class="filter-checkbox-group">
+                        <span class="filter-label">Biến thể:</span>
+                        <div class="checkbox-group" id="variant-checkbox-group">
+                            <label class="custom-checkbox-container">
+                                <input type="checkbox" value="standard" checked onchange="searchTable()">
+                                <span class="checkmark"></span> Cờ tiêu chuẩn
+                            </label>
+                            <label class="custom-checkbox-container">
+                                <input type="checkbox" value="chess960" checked onchange="searchTable()">
+                                <span class="checkmark"></span> Chess960
+                            </label>
+                            <label class="custom-checkbox-container">
+                                <input type="checkbox" value="crazyhouse" checked onchange="searchTable()">
+                                <span class="checkmark"></span> Crazyhouse
+                            </label>
+                            <label class="custom-checkbox-container">
+                                <input type="checkbox" value="bughouse" checked onchange="searchTable()">
+                                <span class="checkmark"></span> Bughouse
+                            </label>
+                            <label class="custom-checkbox-container">
+                                <input type="checkbox" value="kingofthehill" checked onchange="searchTable()">
+                                <span class="checkmark"></span> KOTH
+                            </label>
+                            <label class="custom-checkbox-container">
+                                <input type="checkbox" value="threecheck" checked onchange="searchTable()">
+                                <span class="checkmark"></span> 3 Chiếu
+                            </label>
+                            <label class="custom-checkbox-container">
+                                <input type="checkbox" value="custom" checked onchange="searchTable()">
+                                <span class="checkmark"></span> Custom
+                            </label>
+                        </div>
+                    </div>
                 </div>
             </div>
             <div id="loading-status" style="text-align:center;padding:20px;font-size:14px">Đang hiển thị: <span id="statusIcon" class="bx bx-dots-horizontal-rounded" style="color:var(--primary-warning)"></span> <span id="current-tournament">0</span>/${ids.length} giải đấu</div>

--- a/schedule.html
+++ b/schedule.html
@@ -27,18 +27,18 @@ title: Lịch sự kiện của tháng - CLB Thí Vua Lấy Tốt
             <div class="month-title" id="month-title">Processing...</div>
 
             <div id="schedule-filters" style="display: none; margin-bottom: 25px;">
-                <!-- FIDE style top bar with 1 column centered -->
-                <div class="fide-top-grid" style="grid-template-columns: 1fr; max-width: 320px; margin: 0 auto 15px auto;">
+                <!-- Top bar with 1 column centered -->
+                <div class="tour-top-grid" style="grid-template-columns: 1fr; max-width: 320px; margin: 0 auto 15px auto;">
                     <!-- Column 1: Multi-Select Category Dropdown -->
-                    <div class="fide-dropdown" id="schedule-category-dropdown">
-                        <div class="fide-dropdown-btn" onclick="toggleDropdown('schedule-category-dropdown')">
-                            <div class="fide-dropdown-btn-content">
+                    <div class="tour-dropdown" id="schedule-category-dropdown">
+                        <div class="tour-dropdown-btn" onclick="toggleTourDropdown('schedule-category-dropdown')">
+                            <div class="tour-dropdown-btn-content">
                                 <i class="bx bxs-category"></i>
                                 <span>Thể loại giải</span>
                             </div>
-                            <span class="bx bx-chevron-down fide-dropdown-arrow"></span>
+                            <span class="bx bx-chevron-down tour-dropdown-arrow"></span>
                         </div>
-                        <div class="fide-dropdown-menu" id="schedule-type-group">
+                        <div class="tour-dropdown-menu" id="schedule-type-group">
                             <label class="custom-checkbox-container">
                                 <input type="checkbox" value="tvlt" checked onchange="filterSchedule()">
                                 <span class="checkmark"></span> Thí Vua Lấy Tốt
@@ -79,17 +79,17 @@ title: Lịch sự kiện của tháng - CLB Thí Vua Lấy Tốt
                     </div>
                 </div>
 
-                <!-- FIDE style second bar (Search + Switch) -->
-                <div class="fide-search-row">
-                    <div class="fide-search-wrapper">
-                        <span class="bx bx-search fide-search-icon"></span>
-                        <input type="text" id="schedule-search" class="fide-search-input" placeholder="Tìm tên sự kiện hoặc thông tin giải đấu..." oninput="filterSchedule()">
+                <!-- Second bar (Search + Switch) -->
+                <div class="tour-search-row">
+                    <div class="tour-search-wrapper">
+                        <span class="bx bx-search tour-search-icon"></span>
+                        <input type="text" id="schedule-search" class="tour-search-input" placeholder="Tìm tên sự kiện hoặc thông tin giải đấu..." oninput="filterSchedule()">
                     </div>
 
-                    <label class="fide-switch-container">
-                        <span class="fide-switch">
+                    <label class="tour-switch-container">
+                        <span class="tour-switch">
                             <input type="checkbox" id="schedule-prize-filter" onchange="filterSchedule()">
-                            <span class="fide-slider"></span>
+                            <span class="tour-slider"></span>
                         </span>
                         <span>Chỉ giải có thưởng</span>
                     </label>

--- a/schedule.html
+++ b/schedule.html
@@ -27,24 +27,58 @@ title: Lịch sự kiện của tháng - CLB Thí Vua Lấy Tốt
             <div class="month-title" id="month-title">Processing...</div>
 
             <div id="schedule-filters" class="schedule-filters" style="display: none;">
-                <input type="text" id="schedule-search" placeholder="Tìm tên sự kiện..." oninput="filterSchedule()">
-                <select id="schedule-prize-filter" onchange="filterSchedule()">
-                    <option value="all">Tất cả giải đấu</option>
-                    <option value="prize">Chỉ giải có thưởng</option>
-                </select>
-                <select id="schedule-type-filter" onchange="filterSchedule()">
-                    <option value="all">Tất cả thể loại</option>
-                    <option value="tvlt">Thí Vua Lấy Tốt</option>
-                    <option value="cttq">Chiến Trường Thí Quân</option>
-                    <option value="cbtt">Cờ Bí Thí Tốt</option>
-                    <option value="dttv">Đấu Trường Thí Vua</option>
-                    <option value="multi-club-arena">Multi-Club Arena</option>
-                    <option value="club-arena">Đấu trường Arena</option>
-                    <option value="swiss">Hệ Thụy Sĩ (Swiss)</option>
-                    <option value="1wl">One World League</option>
-                    <option value="vote">Cờ vua bỏ phiếu</option>
-                    <option value="daily">Cờ hàng ngày (Daily)</option>
-                </select>
+                <div class="filter-row-top">
+                    <input type="text" id="schedule-search" placeholder="Tìm tên sự kiện..." oninput="filterSchedule()">
+                    <label class="custom-checkbox-container">
+                        <input type="checkbox" id="schedule-prize-filter" onchange="filterSchedule()">
+                        <span class="checkmark"></span> Chỉ hiển thị giải có thưởng
+                    </label>
+                </div>
+                <div class="filter-row-bottom">
+                    <span class="filter-label">Thể loại giải:</span>
+                    <div class="checkbox-group" id="schedule-type-group">
+                        <label class="custom-checkbox-container">
+                            <input type="checkbox" value="tvlt" checked onchange="filterSchedule()">
+                            <span class="checkmark"></span> Thí Vua Lấy Tốt
+                        </label>
+                        <label class="custom-checkbox-container">
+                            <input type="checkbox" value="cttq" checked onchange="filterSchedule()">
+                            <span class="checkmark"></span> Chiến Trường Thí Quân
+                        </label>
+                        <label class="custom-checkbox-container">
+                            <input type="checkbox" value="cbtt" checked onchange="filterSchedule()">
+                            <span class="checkmark"></span> Cờ Bí Thí Tốt
+                        </label>
+                        <label class="custom-checkbox-container">
+                            <input type="checkbox" value="dttv" checked onchange="filterSchedule()">
+                            <span class="checkmark"></span> Đấu Trường Thí Vua
+                        </label>
+                        <label class="custom-checkbox-container">
+                            <input type="checkbox" value="multi-club-arena" checked onchange="filterSchedule()">
+                            <span class="checkmark"></span> Multi-Club Arena
+                        </label>
+                        <label class="custom-checkbox-container">
+                            <input type="checkbox" value="club-arena" checked onchange="filterSchedule()">
+                            <span class="checkmark"></span> Đấu trường Arena
+                        </label>
+                        <label class="custom-checkbox-container">
+                            <input type="checkbox" value="swiss" checked onchange="filterSchedule()">
+                            <span class="checkmark"></span> Hệ Thụy Sĩ (Swiss)
+                        </label>
+                        <label class="custom-checkbox-container">
+                            <input type="checkbox" value="1wl" checked onchange="filterSchedule()">
+                            <span class="checkmark"></span> One World League
+                        </label>
+                        <label class="custom-checkbox-container">
+                            <input type="checkbox" value="vote" checked onchange="filterSchedule()">
+                            <span class="checkmark"></span> Cờ vua bỏ phiếu
+                        </label>
+                        <label class="custom-checkbox-container">
+                            <input type="checkbox" value="daily" checked onchange="filterSchedule()">
+                            <span class="checkmark"></span> Cờ hàng ngày (Daily)
+                        </label>
+                    </div>
+                </div>
             </div>
 
             <div id="loading" class="loading">

--- a/schedule.html
+++ b/schedule.html
@@ -27,8 +27,8 @@ title: Lịch sự kiện của tháng - CLB Thí Vua Lấy Tốt
             <div class="month-title" id="month-title">Processing...</div>
 
             <div id="schedule-filters" style="display: none; margin-bottom: 25px;">
-                <!-- FIDE style top bar with 3 columns -->
-                <div class="fide-top-grid">
+                <!-- FIDE style top bar with 1 column centered -->
+                <div class="fide-top-grid" style="grid-template-columns: 1fr; max-width: 320px; margin: 0 auto 15px auto;">
                     <!-- Column 1: Multi-Select Category Dropdown -->
                     <div class="fide-dropdown" id="schedule-category-dropdown">
                         <div class="fide-dropdown-btn" onclick="toggleDropdown('schedule-category-dropdown')">
@@ -68,10 +68,6 @@ title: Lịch sự kiện của tháng - CLB Thí Vua Lấy Tốt
                                 <span class="checkmark"></span> Hệ Thụy Sĩ (Swiss)
                             </label>
                             <label class="custom-checkbox-container">
-                                <input type="checkbox" value="1wl" checked onchange="filterSchedule()">
-                                <span class="checkmark"></span> One World League
-                            </label>
-                            <label class="custom-checkbox-container">
                                 <input type="checkbox" value="vote" checked onchange="filterSchedule()">
                                 <span class="checkmark"></span> Cờ vua bỏ phiếu
                             </label>
@@ -80,25 +76,6 @@ title: Lịch sự kiện của tháng - CLB Thí Vua Lấy Tốt
                                 <span class="checkmark"></span> Cờ hàng ngày (Daily)
                             </label>
                         </div>
-                    </div>
-
-                    <!-- Column 2: Organizer Filter -->
-                    <div class="fide-select-container">
-                        <select id="schedule-organizer-filter" class="fide-select-btn" onchange="filterSchedule()">
-                            <option value="all">Tất cả ban tổ chức</option>
-                            <option value="tvlt">CLB Thí Vua Lấy Tốt</option>
-                            <option value="1wl">One World League</option>
-                            <option value="other">Quản trị viên khác</option>
-                        </select>
-                    </div>
-
-                    <!-- Column 3: Day Filter -->
-                    <div class="fide-select-container">
-                        <select id="schedule-day-filter" class="fide-select-btn" onchange="filterSchedule()">
-                            <option value="all">Tất cả các ngày</option>
-                            <option value="weekday">Ngày thường (T2 - T6)</option>
-                            <option value="weekend">Cuối tuần (T7 - CN)</option>
-                        </select>
                     </div>
                 </div>
 

--- a/schedule.html
+++ b/schedule.html
@@ -44,7 +44,7 @@ title: Lịch sự kiện của tháng - CLB Thí Vua Lấy Tốt
                     <div class="tour-dropdown" id="schedule-category-dropdown">
                         <div class="tour-dropdown-btn" onclick="toggleTourDropdown('schedule-category-dropdown')">
                             <div class="tour-dropdown-btn-content">
-                                <i class="bx bxs-category"></i>
+                                <i class="bx bx-medal"></i>
                                 <span>Thể loại giải</span>
                             </div>
                             <span class="bx bx-chevron-down tour-dropdown-arrow"></span>

--- a/schedule.html
+++ b/schedule.html
@@ -22,14 +22,25 @@ title: Lịch sự kiện của tháng - CLB Thí Vua Lấy Tốt
                 <li style="text-align: center;"><strong><span style="font-size: 14px;">Ấn vào icon để xem chi tiết th&ocirc;ng tin sự kiện</span></strong></li>
             </ul>
             <br>
-            <p><i>Lần cuối cập nhật: <span id="last-updated"></span></i>.<br>Nếu có vấn đề hãy bình luận trong <a href="https://chess.com/clubs/forum/view/lich-su-kien-hang-thang-clb-tvlt?clubId=325849&quote_id=125015758&page=1#comment_box" target="_blank">forum này</a> hoặc liên hệ <a href="/leaders#admin3">M-DinhHoangViet</a>.</p>
+            <p><i>Lần cuối cập nhật: <span id="last-updated"></span></i>.<br>Nếu có vấn đề hãy bình luận trong <a href="https://chess.com/clubs/forum/view/lich-su-kien-hang-thang-clb-tvlt?clubId=325849&quote_id=125015758&page=1#comment_box" target="_blank">forum này</a> hoặc liên hệ <a href="/leaders#admin3" target="_top">M-DinhHoangViet</a>.</p>
             <br>
-            <div class="month-title" id="month-title">Processing...</div>
 
             <div id="schedule-filters" style="display: none; margin-bottom: 25px;">
-                <!-- Top bar with 1 column centered -->
+                <div class="tour-search-row">
+                    <div class="tour-search-wrapper">
+                        <span class="bx bx-search tour-search-icon"></span>
+                        <input type="text" id="schedule-search" class="tour-search-input" placeholder="Tìm tên sự kiện hoặc thông tin giải đấu..." oninput="filterSchedule()">
+                    </div>
+
+                    <label class="tour-switch-container">
+                        <span class="tour-switch">
+                            <input type="checkbox" id="schedule-prize-filter" onchange="filterSchedule()">
+                            <span class="tour-slider"></span>
+                        </span>
+                        <span>Chỉ giải có thưởng</span>
+                    </label>
+                </div>
                 <div class="tour-top-grid" style="grid-template-columns: 1fr; max-width: 320px; margin: 0 auto 15px auto;">
-                    <!-- Column 1: Multi-Select Category Dropdown -->
                     <div class="tour-dropdown" id="schedule-category-dropdown">
                         <div class="tour-dropdown-btn" onclick="toggleTourDropdown('schedule-category-dropdown')">
                             <div class="tour-dropdown-btn-content">
@@ -57,7 +68,7 @@ title: Lịch sự kiện của tháng - CLB Thí Vua Lấy Tốt
                             </label>
                             <label class="custom-checkbox-container">
                                 <input type="checkbox" value="multi-club-arena" checked onchange="filterSchedule()">
-                                <span class="checkmark"></span> Multi-Club Arena
+                                <span class="checkmark"></span> Multi-Club Arena (Đấu trường đa CLB)
                             </label>
                             <label class="custom-checkbox-container">
                                 <input type="checkbox" value="club-arena" checked onchange="filterSchedule()">
@@ -69,7 +80,7 @@ title: Lịch sự kiện của tháng - CLB Thí Vua Lấy Tốt
                             </label>
                             <label class="custom-checkbox-container">
                                 <input type="checkbox" value="vote" checked onchange="filterSchedule()">
-                                <span class="checkmark"></span> Cờ vua bỏ phiếu
+                                <span class="checkmark"></span> Cờ vua bỏ phiếu (Votechess)
                             </label>
                             <label class="custom-checkbox-container">
                                 <input type="checkbox" value="daily" checked onchange="filterSchedule()">
@@ -78,24 +89,8 @@ title: Lịch sự kiện của tháng - CLB Thí Vua Lấy Tốt
                         </div>
                     </div>
                 </div>
-
-                <!-- Second bar (Search + Switch) -->
-                <div class="tour-search-row">
-                    <div class="tour-search-wrapper">
-                        <span class="bx bx-search tour-search-icon"></span>
-                        <input type="text" id="schedule-search" class="tour-search-input" placeholder="Tìm tên sự kiện hoặc thông tin giải đấu..." oninput="filterSchedule()">
-                    </div>
-
-                    <label class="tour-switch-container">
-                        <span class="tour-switch">
-                            <input type="checkbox" id="schedule-prize-filter" onchange="filterSchedule()">
-                            <span class="tour-slider"></span>
-                        </span>
-                        <span>Chỉ giải có thưởng</span>
-                    </label>
-                </div>
             </div>
-
+            <div class="month-title" id="month-title">Processing...</div>
             <div id="loading" class="loading">
                 <div class="loading-spinner"></div>
                 <p style="font-size: 1.1em; margin-top: 20px;">Đang tải lịch...</p>

--- a/schedule.html
+++ b/schedule.html
@@ -25,6 +25,28 @@ title: Lịch sự kiện của tháng - CLB Thí Vua Lấy Tốt
             <p><i>Lần cuối cập nhật: <span id="last-updated"></span></i>.<br>Nếu có vấn đề hãy bình luận trong <a href="https://chess.com/clubs/forum/view/lich-su-kien-hang-thang-clb-tvlt?clubId=325849&quote_id=125015758&page=1#comment_box" target="_blank">forum này</a> hoặc liên hệ <a href="/leaders#admin3">M-DinhHoangViet</a>.</p>
             <br>
             <div class="month-title" id="month-title">Processing...</div>
+
+            <div id="schedule-filters" class="schedule-filters" style="display: none;">
+                <input type="text" id="schedule-search" placeholder="Tìm tên sự kiện..." oninput="filterSchedule()">
+                <select id="schedule-prize-filter" onchange="filterSchedule()">
+                    <option value="all">Tất cả giải đấu</option>
+                    <option value="prize">Chỉ giải có thưởng</option>
+                </select>
+                <select id="schedule-type-filter" onchange="filterSchedule()">
+                    <option value="all">Tất cả thể loại</option>
+                    <option value="tvlt">Thí Vua Lấy Tốt</option>
+                    <option value="cttq">Chiến Trường Thí Quân</option>
+                    <option value="cbtt">Cờ Bí Thí Tốt</option>
+                    <option value="dttv">Đấu Trường Thí Vua</option>
+                    <option value="multi-club-arena">Multi-Club Arena</option>
+                    <option value="club-arena">Đấu trường Arena</option>
+                    <option value="swiss">Hệ Thụy Sĩ (Swiss)</option>
+                    <option value="1wl">One World League</option>
+                    <option value="vote">Cờ vua bỏ phiếu</option>
+                    <option value="daily">Cờ hàng ngày (Daily)</option>
+                </select>
+            </div>
+
             <div id="loading" class="loading">
                 <div class="loading-spinner"></div>
                 <p style="font-size: 1.1em; margin-top: 20px;">Đang tải lịch...</p>

--- a/schedule.html
+++ b/schedule.html
@@ -26,61 +26,96 @@ title: Lịch sự kiện của tháng - CLB Thí Vua Lấy Tốt
             <br>
             <div class="month-title" id="month-title">Processing...</div>
 
-            <div id="schedule-filters" class="schedule-filters" style="display: none;">
-                <div class="filter-row-top">
-                    <input type="text" id="schedule-search" placeholder="Tìm tên sự kiện..." oninput="filterSchedule()">
-                    <button type="button" id="schedule-toggle-btn" class="btn-toggle-filters" onclick="toggleScheduleFilters()">
-                        <span class="bx bx-filter-alt"></span> Bộ lọc
-                    </button>
-                    <label class="custom-checkbox-container" style="margin-bottom: 0;">
-                        <input type="checkbox" id="schedule-prize-filter" onchange="filterSchedule()">
-                        <span class="checkmark"></span> Chỉ giải có thưởng
-                    </label>
-                </div>
-                <div class="filter-row-bottom collapsible-panel" id="schedule-collapsible-panel" style="display: none;">
-                    <span class="filter-label">Thể loại giải:</span>
-                    <div class="checkbox-group" id="schedule-type-group">
-                        <label class="custom-checkbox-container">
-                            <input type="checkbox" value="tvlt" checked onchange="filterSchedule()">
-                            <span class="checkmark"></span> Thí Vua Lấy Tốt
-                        </label>
-                        <label class="custom-checkbox-container">
-                            <input type="checkbox" value="cttq" checked onchange="filterSchedule()">
-                            <span class="checkmark"></span> Chiến Trường Thí Quân
-                        </label>
-                        <label class="custom-checkbox-container">
-                            <input type="checkbox" value="cbtt" checked onchange="filterSchedule()">
-                            <span class="checkmark"></span> Cờ Bí Thí Tốt
-                        </label>
-                        <label class="custom-checkbox-container">
-                            <input type="checkbox" value="dttv" checked onchange="filterSchedule()">
-                            <span class="checkmark"></span> Đấu Trường Thí Vua
-                        </label>
-                        <label class="custom-checkbox-container">
-                            <input type="checkbox" value="multi-club-arena" checked onchange="filterSchedule()">
-                            <span class="checkmark"></span> Multi-Club Arena
-                        </label>
-                        <label class="custom-checkbox-container">
-                            <input type="checkbox" value="club-arena" checked onchange="filterSchedule()">
-                            <span class="checkmark"></span> Đấu trường Arena
-                        </label>
-                        <label class="custom-checkbox-container">
-                            <input type="checkbox" value="swiss" checked onchange="filterSchedule()">
-                            <span class="checkmark"></span> Hệ Thụy Sĩ (Swiss)
-                        </label>
-                        <label class="custom-checkbox-container">
-                            <input type="checkbox" value="1wl" checked onchange="filterSchedule()">
-                            <span class="checkmark"></span> One World League
-                        </label>
-                        <label class="custom-checkbox-container">
-                            <input type="checkbox" value="vote" checked onchange="filterSchedule()">
-                            <span class="checkmark"></span> Cờ vua bỏ phiếu
-                        </label>
-                        <label class="custom-checkbox-container">
-                            <input type="checkbox" value="daily" checked onchange="filterSchedule()">
-                            <span class="checkmark"></span> Cờ hàng ngày (Daily)
-                        </label>
+            <div id="schedule-filters" style="display: none; margin-bottom: 25px;">
+                <!-- FIDE style top bar with 3 columns -->
+                <div class="fide-top-grid">
+                    <!-- Column 1: Multi-Select Category Dropdown -->
+                    <div class="fide-dropdown" id="schedule-category-dropdown">
+                        <div class="fide-dropdown-btn" onclick="toggleDropdown('schedule-category-dropdown')">
+                            <div class="fide-dropdown-btn-content">
+                                <i class="bx bxs-category"></i>
+                                <span>Thể loại giải</span>
+                            </div>
+                            <span class="bx bx-chevron-down fide-dropdown-arrow"></span>
+                        </div>
+                        <div class="fide-dropdown-menu" id="schedule-type-group">
+                            <label class="custom-checkbox-container">
+                                <input type="checkbox" value="tvlt" checked onchange="filterSchedule()">
+                                <span class="checkmark"></span> Thí Vua Lấy Tốt
+                            </label>
+                            <label class="custom-checkbox-container">
+                                <input type="checkbox" value="cttq" checked onchange="filterSchedule()">
+                                <span class="checkmark"></span> Chiến Trường Thí Quân
+                            </label>
+                            <label class="custom-checkbox-container">
+                                <input type="checkbox" value="cbtt" checked onchange="filterSchedule()">
+                                <span class="checkmark"></span> Cờ Bí Thí Tốt
+                            </label>
+                            <label class="custom-checkbox-container">
+                                <input type="checkbox" value="dttv" checked onchange="filterSchedule()">
+                                <span class="checkmark"></span> Đấu Trường Thí Vua
+                            </label>
+                            <label class="custom-checkbox-container">
+                                <input type="checkbox" value="multi-club-arena" checked onchange="filterSchedule()">
+                                <span class="checkmark"></span> Multi-Club Arena
+                            </label>
+                            <label class="custom-checkbox-container">
+                                <input type="checkbox" value="club-arena" checked onchange="filterSchedule()">
+                                <span class="checkmark"></span> Đấu trường Arena
+                            </label>
+                            <label class="custom-checkbox-container">
+                                <input type="checkbox" value="swiss" checked onchange="filterSchedule()">
+                                <span class="checkmark"></span> Hệ Thụy Sĩ (Swiss)
+                            </label>
+                            <label class="custom-checkbox-container">
+                                <input type="checkbox" value="1wl" checked onchange="filterSchedule()">
+                                <span class="checkmark"></span> One World League
+                            </label>
+                            <label class="custom-checkbox-container">
+                                <input type="checkbox" value="vote" checked onchange="filterSchedule()">
+                                <span class="checkmark"></span> Cờ vua bỏ phiếu
+                            </label>
+                            <label class="custom-checkbox-container">
+                                <input type="checkbox" value="daily" checked onchange="filterSchedule()">
+                                <span class="checkmark"></span> Cờ hàng ngày (Daily)
+                            </label>
+                        </div>
                     </div>
+
+                    <!-- Column 2: Organizer Filter -->
+                    <div class="fide-select-container">
+                        <select id="schedule-organizer-filter" class="fide-select-btn" onchange="filterSchedule()">
+                            <option value="all">Tất cả ban tổ chức</option>
+                            <option value="tvlt">CLB Thí Vua Lấy Tốt</option>
+                            <option value="1wl">One World League</option>
+                            <option value="other">Quản trị viên khác</option>
+                        </select>
+                    </div>
+
+                    <!-- Column 3: Day Filter -->
+                    <div class="fide-select-container">
+                        <select id="schedule-day-filter" class="fide-select-btn" onchange="filterSchedule()">
+                            <option value="all">Tất cả các ngày</option>
+                            <option value="weekday">Ngày thường (T2 - T6)</option>
+                            <option value="weekend">Cuối tuần (T7 - CN)</option>
+                        </select>
+                    </div>
+                </div>
+
+                <!-- FIDE style second bar (Search + Switch) -->
+                <div class="fide-search-row">
+                    <div class="fide-search-wrapper">
+                        <span class="bx bx-search fide-search-icon"></span>
+                        <input type="text" id="schedule-search" class="fide-search-input" placeholder="Tìm tên sự kiện hoặc thông tin giải đấu..." oninput="filterSchedule()">
+                    </div>
+
+                    <label class="fide-switch-container">
+                        <span class="fide-switch">
+                            <input type="checkbox" id="schedule-prize-filter" onchange="filterSchedule()">
+                            <span class="fide-slider"></span>
+                        </span>
+                        <span>Chỉ giải có thưởng</span>
+                    </label>
                 </div>
             </div>
 

--- a/schedule.html
+++ b/schedule.html
@@ -29,12 +29,15 @@ title: Lịch sự kiện của tháng - CLB Thí Vua Lấy Tốt
             <div id="schedule-filters" class="schedule-filters" style="display: none;">
                 <div class="filter-row-top">
                     <input type="text" id="schedule-search" placeholder="Tìm tên sự kiện..." oninput="filterSchedule()">
-                    <label class="custom-checkbox-container">
+                    <button type="button" id="schedule-toggle-btn" class="btn-toggle-filters" onclick="toggleScheduleFilters()">
+                        <span class="bx bx-filter-alt"></span> Bộ lọc
+                    </button>
+                    <label class="custom-checkbox-container" style="margin-bottom: 0;">
                         <input type="checkbox" id="schedule-prize-filter" onchange="filterSchedule()">
-                        <span class="checkmark"></span> Chỉ hiển thị giải có thưởng
+                        <span class="checkmark"></span> Chỉ giải có thưởng
                     </label>
                 </div>
-                <div class="filter-row-bottom">
+                <div class="filter-row-bottom collapsible-panel" id="schedule-collapsible-panel" style="display: none;">
                     <span class="filter-label">Thể loại giải:</span>
                     <div class="checkbox-group" id="schedule-type-group">
                         <label class="custom-checkbox-container">


### PR DESCRIPTION
This change implements robust client-side filters for the Schedule calendar (filtering by search query, prize status, and tournament category) and advanced sorting/filtering for the TVLT, DTTV, and CBTT tournament lists (sorting by date or player count, and filtering by time control or chess variant). All elements are styled with the neon dark tech aesthetic and are fully responsive on mobile viewports.

---
*PR created automatically by Jules for task [2740349502041334301](https://jules.google.com/task/2740349502041334301) started by @M-DinhHoangViet*